### PR TITLE
Run CI when copy-pr-bot creates PR refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,6 @@
 name: CI
 
 on:
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".gitignore"
   push:
     branches:
       - "pull-request/[0-9]+"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 name: CI
 
 on:
-  create:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
   push:
     branches:
       - "pull-request/[0-9]+"
@@ -22,9 +29,6 @@ jobs:
 
   lint:
     name: Linter Check
-    # copy-pr-bot creates pull-request/N refs before it pushes later updates.
-    # Include that create event, but do not run CI for ordinary branch creation.
-    if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -46,7 +50,6 @@ jobs:
     # fail-fast: false so divergence between Python versions or OSes
     # surfaces all at once rather than one-at-a-time.
     name: Unit tests [py${{ matrix.python }} on ${{ matrix.os }}]
-    if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  create:
   push:
     branches:
       - "pull-request/[0-9]+"
@@ -21,6 +22,9 @@ jobs:
 
   lint:
     name: Linter Check
+    # copy-pr-bot creates pull-request/N refs before it pushes later updates.
+    # Include that create event, but do not run CI for ordinary branch creation.
+    if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -42,6 +46,7 @@ jobs:
     # fail-fast: false so divergence between Python versions or OSes
     # surfaces all at once rather than one-at-a-time.
     name: Unit tests [py${{ matrix.python }} on ${{ matrix.os }}]
+    if: github.event_name != 'create' || startsWith(github.ref, 'refs/heads/pull-request/')
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     strategy:
@@ -338,4 +343,3 @@ jobs:
           generate_release_notes: true
           name: "CompileIQ v${{ github.ref_name }}"
           draft: true
-


### PR DESCRIPTION
The hypothesis for why CI appears to not run on PRs at the moment when expected:  `copy-pr-bot` creates `pull-request/N` refs when a PR opens, but the CI workflow is only configured currently to watch `push` events. A branch create event can therefore leave a PR with no checks until a later update pushes the mirror ref.

This PR changes that in an attempt to fix the issue (CI should run here successfully if the hypothesis is correct) by adding watch on the `create` event as well (but checks are added to ensure we do not run the CI on ANY branch creation event, it needs to be a pull-request branch).