### PR TITLE
Adding Booster Pack documentation

### DIFF
--- a/docs/_static/decode_acf_s_curve_full.svg
+++ b/docs/_static/decode_acf_s_curve_full.svg
@@ -1,0 +1,373 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="900" viewBox="0 0 1480 900">
+<rect width="100%" height="100%" fill="#ffffff"/>
+<text x="86.00" y="36.00" font-size="29" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#111827" text-anchor="start">FlashInfer Batch Decode B200 ACF Gains - Full</text>
+<text x="86.00" y="62.00" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#4b5563" text-anchor="start">Sorted gain from ACF median time versus baseline median time. Higher is better.</text>
+
+<rect x="86" y="96" width="938" height="712" fill="#f9fafb" stroke="#d1d5db"/>
+<line x1="80" y1="808.00" x2="1024" y2="808.00" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="813.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">-17.8%</text>
+<line x1="80" y1="665.60" x2="1024" y2="665.60" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="670.60" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">-10.7%</text>
+<line x1="80" y1="523.20" x2="1024" y2="523.20" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="528.20" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">-3.6%</text>
+<line x1="80" y1="380.80" x2="1024" y2="380.80" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="385.80" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">3.6%</text>
+<line x1="80" y1="238.40" x2="1024" y2="238.40" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="243.40" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">10.7%</text>
+<line x1="80" y1="96.00" x2="1024" y2="96.00" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="101.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">17.8%</text>
+<line x1="86" y1="452.00" x2="1024" y2="452.00" stroke="#111827" stroke-width="1.4" stroke-dasharray="6 5"/>
+<text x="1020.00" y="443.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="end">0% baseline</text>
+<polyline points="86.00,758.90 101.90,758.90 117.80,754.10 133.69,461.59 149.59,456.80 165.49,456.16 181.39,454.40 197.29,454.40 213.19,454.40 229.08,454.40 244.98,452.00 260.88,452.00 276.78,452.00 292.68,452.00 308.58,452.00 324.47,452.00 340.37,452.00 356.27,452.00 372.17,452.00 388.07,452.00 403.97,452.00 419.86,452.00 435.76,452.00 451.66,452.00 467.56,452.00 483.46,452.00 499.36,452.00 515.25,452.00 531.15,452.00 547.05,452.00 562.95,452.00 578.85,452.00 594.75,452.00 610.64,452.00 626.54,452.00 642.44,452.00 658.34,452.00 674.24,452.00 690.14,449.92 706.03,449.92 721.93,449.92 737.83,449.92 753.73,449.92 769.63,447.87 785.53,447.87 801.42,447.84 817.32,447.84 833.22,447.84 849.12,447.84 865.02,447.22 880.92,447.22 896.81,447.20 912.71,445.80 928.61,443.69 944.51,263.78 960.41,262.30 976.31,262.30 992.20,149.90 1008.10,145.10 1024.00,145.10" fill="none" stroke="#2563eb" stroke-width="2.4"/>
+<circle cx="86.00" cy="758.90" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 18-fp8_group_quant_6-604935e94e7b.acf
+gain=-15.38%
+ratio=1.153846
+baseline_ms=0.013311999850
+acf_ms=0.015359999612</title></circle>
+<text x="86.00" y="775.90" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R1</text>
+<circle cx="101.90" cy="758.90" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 19-recompute_w_u_fwd_0-ddaf5128d619.acf
+gain=-15.38%
+ratio=1.153846
+baseline_ms=0.013311999850
+acf_ms=0.015359999612</title></circle>
+<text x="101.90" y="775.90" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R2</text>
+<circle cx="117.80" cy="754.10" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 01-causal_conv_1-34795e1779b7.acf
+gain=-15.14%
+ratio=1.151442
+baseline_ms=0.013311999850
+acf_ms=0.015328000300</title></circle>
+<text x="117.80" y="771.10" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R3</text>
+<circle cx="133.69" cy="461.59" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 20-recompute_w_u_fwd_1-cf6163fdbb39.acf
+gain=-0.48%
+ratio=1.004808
+baseline_ms=0.013311999850
+acf_ms=0.013376000337</title></circle>
+<text x="133.69" y="478.59" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R4</text>
+<circle cx="149.59" cy="456.80" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 15-fp8_group_quant_3-9b3899b0437c.acf
+gain=-0.24%
+ratio=1.002404
+baseline_ms=0.013311999850
+acf_ms=0.013344000094</title></circle>
+<text x="149.59" y="473.80" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R5</text>
+<circle cx="165.49" cy="456.16" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv2048 | 15-fp8_group_quant_3-9b3899b0437c.acf
+gain=-0.21%
+ratio=1.002083
+baseline_ms=0.015359999612
+acf_ms=0.015391999856</title></circle>
+<circle cx="181.39" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 04-chunk_fwd_h_1-1ba1395526ea.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="197.29" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 05-chunk_fwd_o_0-90bcd5667aaa.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="213.19" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 08-chunk_fwd_o_3-3da87b881f6c.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="229.08" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 09-chunk_fwd_o_4-c9402a37f06c.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="244.98" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 00-causal_conv_0-c3288601ffdf.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="260.88" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 02-causal_conv_2-a3c5ee92e579.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="276.78" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 03-chunk_fwd_h_0-c070e427757e.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="292.68" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 06-chunk_fwd_o_1-1bf10a87b31c.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="308.58" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="324.47" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 10-chunk_fwd_o_5-0f83e0ccadaf.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="340.37" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 11-chunk_fwd_o_6-69a07c8225cc.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="356.27" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 13-fp8_group_quant_1-1de814ccc6c2.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="372.17" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="388.07" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 16-fp8_group_quant_4-968547e81f8f.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="403.97" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 17-fp8_group_quant_5-e30a78520199.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="419.86" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="435.76" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 22-recompute_w_u_fwd_3-fbc6db7c6710.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="451.66" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 23-recompute_w_u_fwd_4-3cef9f16a524.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="467.56" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 02-causal_conv_2-a3c5ee92e579.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="483.46" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 03-chunk_fwd_h_0-c070e427757e.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="499.36" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 04-chunk_fwd_h_1-1ba1395526ea.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="515.25" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="531.15" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 09-chunk_fwd_o_4-c9402a37f06c.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="547.05" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 10-chunk_fwd_o_5-0f83e0ccadaf.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="562.95" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 11-chunk_fwd_o_6-69a07c8225cc.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="578.85" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 12-fp8_group_quant_0-254db792c99b.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="594.75" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 13-fp8_group_quant_1-1de814ccc6c2.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="610.64" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="626.54" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 16-fp8_group_quant_4-968547e81f8f.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="642.44" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 20-recompute_w_u_fwd_1-cf6163fdbb39.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="658.34" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="674.24" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b8_kv128 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013344000094
+acf_ms=0.013344000094</title></circle>
+<circle cx="690.14" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 01-causal_conv_1-34795e1779b7.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="706.03" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 05-chunk_fwd_o_0-90bcd5667aaa.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="721.93" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 08-chunk_fwd_o_3-3da87b881f6c.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="737.83" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 19-recompute_w_u_fwd_0-ddaf5128d619.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="753.73" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 22-recompute_w_u_fwd_3-fbc6db7c6710.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="769.63" cy="447.87" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv512 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+0.21%
+ratio=0.997930
+baseline_ms=0.015456000343
+acf_ms=0.015424000099</title></circle>
+<circle cx="785.53" cy="447.87" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv512 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+0.21%
+ratio=0.997930
+baseline_ms=0.015456000343
+acf_ms=0.015424000099</title></circle>
+<circle cx="801.42" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 00-causal_conv_0-c3288601ffdf.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="817.32" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 06-chunk_fwd_o_1-1bf10a87b31c.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="833.22" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 18-fp8_group_quant_6-604935e94e7b.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="849.12" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 23-recompute_w_u_fwd_4-3cef9f16a524.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="865.02" cy="447.22" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv128 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+0.24%
+ratio=0.997602
+baseline_ms=0.013344000094
+acf_ms=0.013311999850</title></circle>
+<circle cx="880.92" cy="447.22" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv128 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+0.24%
+ratio=0.997602
+baseline_ms=0.013344000094
+acf_ms=0.013311999850</title></circle>
+<circle cx="896.81" cy="447.20" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv512 | 12-fp8_group_quant_0-254db792c99b.acf
+gain=+0.24%
+ratio=0.997596
+baseline_ms=0.013311999850
+acf_ms=0.013279999606</title></circle>
+<circle cx="912.71" cy="445.80" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv512 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+0.31%
+ratio=0.996894
+baseline_ms=0.015456000343
+acf_ms=0.015407999977</title></circle>
+<circle cx="928.61" cy="443.69" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 17-fp8_group_quant_5-e30a78520199.acf
+gain=+0.42%
+ratio=0.995833
+baseline_ms=0.015359999612
+acf_ms=0.015296000056</title></circle>
+<circle cx="944.51" cy="263.78" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv8192 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+9.44%
+ratio=0.905646
+baseline_ms=0.021536000073
+acf_ms=0.019503999501</title></circle>
+<circle cx="960.41" cy="262.30" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv8192 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+9.51%
+ratio=0.904903
+baseline_ms=0.021536000073
+acf_ms=0.019487999380</title></circle>
+<text x="960.41" y="251.30" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U5</text>
+<circle cx="976.31" cy="262.30" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv8192 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+9.51%
+ratio=0.904903
+baseline_ms=0.021536000073
+acf_ms=0.019487999380</title></circle>
+<text x="976.31" y="251.30" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U4</text>
+<circle cx="992.20" cy="149.90" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv128 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+15.14%
+ratio=0.848558
+baseline_ms=0.013311999850
+acf_ms=0.011296000332</title></circle>
+<text x="992.20" y="138.90" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U3</text>
+<circle cx="1008.10" cy="145.10" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv128 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+15.38%
+ratio=0.846154
+baseline_ms=0.013311999850
+acf_ms=0.011264000088</title></circle>
+<text x="1008.10" y="134.10" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U2</text>
+<circle cx="1024.00" cy="145.10" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv128 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+15.38%
+ratio=0.846154
+baseline_ms=0.013311999850
+acf_ms=0.011264000088</title></circle>
+<text x="1024.00" y="134.10" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U1</text>
+<rect x="1034" y="96" width="408" height="712" fill="#ffffff" stroke="#d1d5db"/>
+<text x="1052.00" y="128.00" font-size="20" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#111827" text-anchor="start">Visible case callouts</text>
+<text x="1052.00" y="154.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#4b5563" text-anchor="start">Labels on the curve map to shape and ACF here.</text>
+<text x="1052.00" y="192.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">Top gains</text>
+<text x="1052.00" y="222.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U1 +15.38%</text>
+<text x="1146.00" y="222.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv128 | 21-recompute_w_u_fwd_2-48fb75d9d7...</text>
+<text x="1146.00" y="239.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.011264 ms</text>
+<text x="1052.00" y="268.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U2 +15.38%</text>
+<text x="1146.00" y="268.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv128 | 07-chunk_fwd_o_2-6bd7110b3f18.acf</text>
+<text x="1146.00" y="285.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.011264 ms</text>
+<text x="1052.00" y="314.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U3 +15.14%</text>
+<text x="1146.00" y="314.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv128 | 14-fp8_group_quant_2-26b3240d07b7...</text>
+<text x="1146.00" y="331.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.011296 ms</text>
+<text x="1052.00" y="360.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U4 +9.51%</text>
+<text x="1146.00" y="360.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv8192 | 21-recompute_w_u_fwd_2-48fb75d9d7...</text>
+<text x="1146.00" y="377.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.021536 ms acf=0.019488 ms</text>
+<text x="1052.00" y="406.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U5 +9.51%</text>
+<text x="1146.00" y="406.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv8192 | 14-fp8_group_quant_2-26b3240d07b7...</text>
+<text x="1146.00" y="423.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.021536 ms acf=0.019488 ms</text>
+<text x="1052.00" y="486.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">Largest regressions</text>
+<text x="1052.00" y="518.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R1 -15.38%</text>
+<text x="1146.00" y="518.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 18-fp8_group_quant_6-604935e94e7b...</text>
+<text x="1146.00" y="535.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.015360 ms</text>
+<text x="1052.00" y="564.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R2 -15.38%</text>
+<text x="1146.00" y="564.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 19-recompute_w_u_fwd_0-ddaf5128d6...</text>
+<text x="1146.00" y="581.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.015360 ms</text>
+<text x="1052.00" y="610.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R3 -15.14%</text>
+<text x="1146.00" y="610.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 01-causal_conv_1-34795e1779b7.acf</text>
+<text x="1146.00" y="627.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.015328 ms</text>
+<text x="1052.00" y="656.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R4 -0.48%</text>
+<text x="1146.00" y="656.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 20-recompute_w_u_fwd_1-cf6163fdbb...</text>
+<text x="1146.00" y="673.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.013376 ms</text>
+<text x="1052.00" y="702.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R5 -0.24%</text>
+<text x="1146.00" y="702.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 15-fp8_group_quant_3-9b3899b0437c...</text>
+<text x="1146.00" y="719.00" font-size="12" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.013344 ms</text>
+<line x1="86" y1="808" x2="1024" y2="808" stroke="#111827"/>
+<line x1="86" y1="96" x2="86" y2="808" stroke="#111827"/>
+<text x="555.00" y="866.00" font-size="16" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="middle">ACF attempts sorted by gain</text>
+<text transform="translate(24 452.00) rotate(-90)" text-anchor="middle" font-size="16" font-family="NVIDIA Sans, Arial, sans-serif" fill="#111827">Gain vs baseline (%)</text>
+<text x="86.00" y="836.00" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="start">shown=60 total=60 improved=22 neutral_abs_le_1pct=51 below_baseline=10</text>
+<text x="1024.00" y="836.00" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">min=-15.38% median=+0.00% max=+15.38%</text>
+</svg>

--- a/docs/_static/decode_acf_s_curve_summary.svg
+++ b/docs/_static/decode_acf_s_curve_summary.svg
@@ -1,0 +1,258 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1480" height="900" viewBox="0 0 1480 900">
+<rect width="100%" height="100%" fill="#ffffff"/>
+<text x="86.00" y="36.00" font-size="29" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#111827" text-anchor="start">FlashInfer Batch Decode B200 ACF Gains - Summary</text>
+<text x="86.00" y="62.00" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#4b5563" text-anchor="start">Sorted gain from ACF median time versus baseline median time. Higher is better.</text>
+<text x="86.00" y="84.00" font-size="13" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">Summary view: all non-zero effects plus 5 middle zero-effect points; omitted 23 zero-effect points.</text>
+<rect x="86" y="96" width="740" height="712" fill="#f9fafb" stroke="#d1d5db"/>
+<line x1="80" y1="808.00" x2="826" y2="808.00" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="813.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">-17.8%</text>
+<line x1="80" y1="665.60" x2="826" y2="665.60" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="670.60" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">-10.7%</text>
+<line x1="80" y1="523.20" x2="826" y2="523.20" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="528.20" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">-3.6%</text>
+<line x1="80" y1="380.80" x2="826" y2="380.80" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="385.80" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">3.6%</text>
+<line x1="80" y1="238.40" x2="826" y2="238.40" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="243.40" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">10.7%</text>
+<line x1="80" y1="96.00" x2="826" y2="96.00" stroke="#e5e7eb" stroke-width="1"/>
+<text x="74.00" y="101.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">17.8%</text>
+<line x1="86" y1="452.00" x2="826" y2="452.00" stroke="#111827" stroke-width="1.4" stroke-dasharray="6 5"/>
+<text x="822.00" y="443.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="end">0% baseline</text>
+<polyline points="86.00,758.90 106.56,758.90 127.11,754.10 147.67,461.59 168.22,456.80 188.78,456.16 209.33,454.40 229.89,454.40 250.44,454.40 271.00,454.40 291.56,452.00 312.11,452.00 332.67,452.00 353.22,452.00 373.78,452.00 394.33,449.92 414.89,449.92 435.44,449.92 456.00,449.92 476.56,449.92 497.11,447.87 517.67,447.87 538.22,447.84 558.78,447.84 579.33,447.84 599.89,447.84 620.44,447.22 641.00,447.22 661.56,447.20 682.11,445.80 702.67,443.69 723.22,263.78 743.78,262.30 764.33,262.30 784.89,149.90 805.44,145.10 826.00,145.10" fill="none" stroke="#2563eb" stroke-width="2.4"/>
+<circle cx="86.00" cy="758.90" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 18-fp8_group_quant_6-604935e94e7b.acf
+gain=-15.38%
+ratio=1.153846
+baseline_ms=0.013311999850
+acf_ms=0.015359999612</title></circle>
+<text x="86.00" y="778.90" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R1</text>
+<circle cx="106.56" cy="758.90" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 19-recompute_w_u_fwd_0-ddaf5128d619.acf
+gain=-15.38%
+ratio=1.153846
+baseline_ms=0.013311999850
+acf_ms=0.015359999612</title></circle>
+<text x="106.56" y="778.90" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R2</text>
+<circle cx="127.11" cy="754.10" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 01-causal_conv_1-34795e1779b7.acf
+gain=-15.14%
+ratio=1.151442
+baseline_ms=0.013311999850
+acf_ms=0.015328000300</title></circle>
+<text x="127.11" y="774.10" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R3</text>
+<circle cx="147.67" cy="461.59" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 20-recompute_w_u_fwd_1-cf6163fdbb39.acf
+gain=-0.48%
+ratio=1.004808
+baseline_ms=0.013311999850
+acf_ms=0.013376000337</title></circle>
+<text x="147.67" y="481.59" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R4</text>
+<circle cx="168.22" cy="456.80" r="6.2" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 15-fp8_group_quant_3-9b3899b0437c.acf
+gain=-0.24%
+ratio=1.002404
+baseline_ms=0.013311999850
+acf_ms=0.013344000094</title></circle>
+<text x="168.22" y="476.80" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="middle">R5</text>
+<circle cx="188.78" cy="456.16" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv2048 | 15-fp8_group_quant_3-9b3899b0437c.acf
+gain=-0.21%
+ratio=1.002083
+baseline_ms=0.015359999612
+acf_ms=0.015391999856</title></circle>
+<circle cx="209.33" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 04-chunk_fwd_h_1-1ba1395526ea.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="229.89" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 05-chunk_fwd_o_0-90bcd5667aaa.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="250.44" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 08-chunk_fwd_o_3-3da87b881f6c.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="271.00" cy="454.40" r="4.5" fill="#b91c1c" opacity="0.92"><title>b1_kv512 | 09-chunk_fwd_o_4-c9402a37f06c.acf
+gain=-0.12%
+ratio=1.001202
+baseline_ms=0.013311999850
+acf_ms=0.013327999972</title></circle>
+<circle cx="291.56" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="312.11" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 22-recompute_w_u_fwd_3-fbc6db7c6710.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="332.67" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv512 | 23-recompute_w_u_fwd_4-3cef9f16a524.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.013311999850
+acf_ms=0.013311999850</title></circle>
+<circle cx="353.22" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 02-causal_conv_2-a3c5ee92e579.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="373.78" cy="452.00" r="4.5" fill="#6b7280" opacity="0.92"><title>b1_kv2048 | 03-chunk_fwd_h_0-c070e427757e.acf
+gain=+0.00%
+ratio=1.000000
+baseline_ms=0.015359999612
+acf_ms=0.015359999612</title></circle>
+<circle cx="394.33" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 01-causal_conv_1-34795e1779b7.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="414.89" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 05-chunk_fwd_o_0-90bcd5667aaa.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="435.44" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 08-chunk_fwd_o_3-3da87b881f6c.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="456.00" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 19-recompute_w_u_fwd_0-ddaf5128d619.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="476.56" cy="449.92" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 22-recompute_w_u_fwd_3-fbc6db7c6710.acf
+gain=+0.10%
+ratio=0.998958
+baseline_ms=0.015359999612
+acf_ms=0.015343999956</title></circle>
+<circle cx="497.11" cy="447.87" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv512 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+0.21%
+ratio=0.997930
+baseline_ms=0.015456000343
+acf_ms=0.015424000099</title></circle>
+<circle cx="517.67" cy="447.87" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv512 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+0.21%
+ratio=0.997930
+baseline_ms=0.015456000343
+acf_ms=0.015424000099</title></circle>
+<circle cx="538.22" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 00-causal_conv_0-c3288601ffdf.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="558.78" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 06-chunk_fwd_o_1-1bf10a87b31c.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="579.33" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 18-fp8_group_quant_6-604935e94e7b.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="599.89" cy="447.84" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 23-recompute_w_u_fwd_4-3cef9f16a524.acf
+gain=+0.21%
+ratio=0.997917
+baseline_ms=0.015359999612
+acf_ms=0.015328000300</title></circle>
+<circle cx="620.44" cy="447.22" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv128 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+0.24%
+ratio=0.997602
+baseline_ms=0.013344000094
+acf_ms=0.013311999850</title></circle>
+<circle cx="641.00" cy="447.22" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv128 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+0.24%
+ratio=0.997602
+baseline_ms=0.013344000094
+acf_ms=0.013311999850</title></circle>
+<circle cx="661.56" cy="447.20" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv512 | 12-fp8_group_quant_0-254db792c99b.acf
+gain=+0.24%
+ratio=0.997596
+baseline_ms=0.013311999850
+acf_ms=0.013279999606</title></circle>
+<circle cx="682.11" cy="445.80" r="4.5" fill="#047857" opacity="0.92"><title>b8_kv512 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+0.31%
+ratio=0.996894
+baseline_ms=0.015456000343
+acf_ms=0.015407999977</title></circle>
+<circle cx="702.67" cy="443.69" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv2048 | 17-fp8_group_quant_5-e30a78520199.acf
+gain=+0.42%
+ratio=0.995833
+baseline_ms=0.015359999612
+acf_ms=0.015296000056</title></circle>
+<circle cx="723.22" cy="263.78" r="4.5" fill="#047857" opacity="0.92"><title>b1_kv8192 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+9.44%
+ratio=0.905646
+baseline_ms=0.021536000073
+acf_ms=0.019503999501</title></circle>
+<circle cx="743.78" cy="262.30" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv8192 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+9.51%
+ratio=0.904903
+baseline_ms=0.021536000073
+acf_ms=0.019487999380</title></circle>
+<text x="743.78" y="248.30" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U5</text>
+<circle cx="764.33" cy="262.30" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv8192 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+9.51%
+ratio=0.904903
+baseline_ms=0.021536000073
+acf_ms=0.019487999380</title></circle>
+<text x="764.33" y="248.30" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U4</text>
+<circle cx="784.89" cy="149.90" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv128 | 14-fp8_group_quant_2-26b3240d07b7.acf
+gain=+15.14%
+ratio=0.848558
+baseline_ms=0.013311999850
+acf_ms=0.011296000332</title></circle>
+<text x="784.89" y="135.90" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U3</text>
+<circle cx="805.44" cy="145.10" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv128 | 07-chunk_fwd_o_2-6bd7110b3f18.acf
+gain=+15.38%
+ratio=0.846154
+baseline_ms=0.013311999850
+acf_ms=0.011264000088</title></circle>
+<text x="805.44" y="131.10" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U2</text>
+<circle cx="826.00" cy="145.10" r="6.2" fill="#047857" opacity="0.92"><title>b1_kv128 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf
+gain=+15.38%
+ratio=0.846154
+baseline_ms=0.013311999850
+acf_ms=0.011264000088</title></circle>
+<text x="826.00" y="131.10" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="middle">U1</text>
+<rect x="836" y="96" width="606" height="712" fill="#ffffff" stroke="#d1d5db"/>
+<text x="854.00" y="128.00" font-size="23" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#111827" text-anchor="start">Visible case callouts</text>
+<text x="854.00" y="154.00" font-size="16" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#4b5563" text-anchor="start">Labels on the curve map to shape and ACF here.</text>
+<text x="854.00" y="192.00" font-size="20" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">Top gains</text>
+<text x="854.00" y="222.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U1 +15.38%</text>
+<text x="962.00" y="222.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv128 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf</text>
+<text x="962.00" y="241.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.011264 ms</text>
+<text x="854.00" y="274.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U2 +15.38%</text>
+<text x="962.00" y="274.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv128 | 07-chunk_fwd_o_2-6bd7110b3f18.acf</text>
+<text x="962.00" y="293.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.011264 ms</text>
+<text x="854.00" y="326.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U3 +15.14%</text>
+<text x="962.00" y="326.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv128 | 14-fp8_group_quant_2-26b3240d07b7.acf</text>
+<text x="962.00" y="345.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.011296 ms</text>
+<text x="854.00" y="378.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U4 +9.51%</text>
+<text x="962.00" y="378.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv8192 | 21-recompute_w_u_fwd_2-48fb75d9d73a.acf</text>
+<text x="962.00" y="397.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.021536 ms acf=0.019488 ms</text>
+<text x="854.00" y="430.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#047857" text-anchor="start">U5 +9.51%</text>
+<text x="962.00" y="430.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv8192 | 14-fp8_group_quant_2-26b3240d07b7.acf</text>
+<text x="962.00" y="449.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.021536 ms acf=0.019488 ms</text>
+<text x="854.00" y="516.00" font-size="20" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">Largest regressions</text>
+<text x="854.00" y="548.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R1 -15.38%</text>
+<text x="962.00" y="548.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 18-fp8_group_quant_6-604935e94e7b.acf</text>
+<text x="962.00" y="567.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.015360 ms</text>
+<text x="854.00" y="600.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R2 -15.38%</text>
+<text x="962.00" y="600.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 19-recompute_w_u_fwd_0-ddaf5128d619.acf</text>
+<text x="962.00" y="619.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.015360 ms</text>
+<text x="854.00" y="652.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R3 -15.14%</text>
+<text x="962.00" y="652.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 01-causal_conv_1-34795e1779b7.acf</text>
+<text x="962.00" y="671.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.015328 ms</text>
+<text x="854.00" y="704.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R4 -0.48%</text>
+<text x="962.00" y="704.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 20-recompute_w_u_fwd_1-cf6163fdbb39.acf</text>
+<text x="962.00" y="723.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.013376 ms</text>
+<text x="854.00" y="756.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="700" fill="#b91c1c" text-anchor="start">R5 -0.24%</text>
+<text x="962.00" y="756.00" font-size="17" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="start">b1_kv512 | 15-fp8_group_quant_3-9b3899b0437c.acf</text>
+<text x="962.00" y="775.00" font-size="14" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#6b7280" text-anchor="start">baseline=0.013312 ms acf=0.013344 ms</text>
+<line x1="86" y1="808" x2="826" y2="808" stroke="#111827"/>
+<line x1="86" y1="96" x2="86" y2="808" stroke="#111827"/>
+<text x="456.00" y="866.00" font-size="16" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#111827" text-anchor="middle">ACF attempts sorted by gain</text>
+<text transform="translate(24 452.00) rotate(-90)" text-anchor="middle" font-size="16" font-family="NVIDIA Sans, Arial, sans-serif" fill="#111827">Gain vs baseline (%)</text>
+<text x="86.00" y="836.00" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="start">shown=37 total=60 improved=22 neutral_abs_le_1pct=28 below_baseline=10</text>
+<text x="826.00" y="836.00" font-size="15" font-family="NVIDIA Sans, Arial, sans-serif" font-weight="400" fill="#374151" text-anchor="end">min=-15.38% median=+0.10% max=+15.38%</text>
+</svg>

--- a/docs/booster_packs.md
+++ b/docs/booster_packs.md
@@ -35,7 +35,7 @@ For example, the Helion Booster Pack has shown beneficial impact on FlashInfer's
 
 ## Downloading a Booster Pack
 
-Booster Packs will be published as zip assets on the [CompileIQ GitHub Releases page](https://github.com/NVIDIA/CompileIQ/releases) under Booster Pack catalog releases, tagged with a Booster Pack-specific prefix, for example `booster-packs-*`.
+Booster Packs will be published as zip assets on the [CompileIQ GitHub Releases page](https://github.com/NVIDIA/CompileIQ/releases) under a Booster Pack catalog release, tagged with a Booster Pack-specific prefix, for example `booster-packs-*`.
 
 
 * Each Booster Pack catalog release will contain the complete set of Booster Pack zip assets that are currently supported for that catalog version, so users can go to one release to find every supported pack.

--- a/docs/booster_packs.md
+++ b/docs/booster_packs.md
@@ -1,0 +1,112 @@
+# Booster Packs
+
+Booster Packs are GitHub Release zip files that contain curated Advanced Controls Files (ACFs) for specific workload families.
+
+The goal is to give you a practical starting point. Instead of running a full CompileIQ search, first you can try curated candidates that are known to help specific workloads. If one of them passes validation and improves your target workload, you may choose not to run a search for that case.
+
+> Note: Booster Packs are not guaranteed speedups. Treat every ACF as workload-specific and environment-specific.
+
+## Choose the Right Path
+
+| If this is true | Use this path |
+|-----------------|---------------|
+| Your workload is close to a Booster Pack's intended workload, compiler, GPU target, and validation context. | Try the Booster Pack first. |
+| Your workload differs materially from the pack context, the pack candidates do not help, or you need production confidence for one exact target. | Run a full CompileIQ search. |
+| You do not have a stable baseline, correctness check, compiler path, or benchmark setup yet. | Wait. Do not apply a pack or run a search until those are in place. |
+
+## Before You Use a Pack
+
+Before trying a Booster Pack, run a baseline without an ACF and record the environment you used for that baseline. Evaluate the variability of your benchmark; make sure to follow good profiling practices to avoid measurements with high variability.
+
+Adapt your code to handle failures: Applying an ACF can cause compilation errors, compile hangs, runtime crashes, wrong answers, performance regressions, or noisy measurements. That is normal for this workflow. Keep the candidates that pass your validation and reject the rest.
+
+For the broader ACF risk model, read the [compiler tuning overview](compilers_overview.md) before using a Booster Pack.
+
+## Available Booster Packs
+
+| Booster Pack | Intended use |
+|--------------|--------------|
+| Helion Booster Pack | ACFs known to help these Helion kernels: FP8 Quantization, Causal Depthwise Convolution, Gated DeltaNet Forward. |
+| Debug Pack | Diagnostic ACFs that disable or alter selected optimizations to assist debugging. |
+
+The pack name tells you where the ACFs were found or validated. It is not a hard boundary. Related workloads may benefit, but you must test them.
+
+For example, the Helion Booster Pack has shown beneficial impact on FlashInfer's `BatchDecodeWithPagedKVCacheWrapper` benchmark.
+
+## Downloading a Booster Pack
+
+Booster Packs will be published as zip assets on the [CompileIQ GitHub Releases page](https://github.com/NVIDIA/CompileIQ/releases) under Booster Pack catalog releases, tagged with a Booster Pack-specific prefix, for example `booster-packs-*`.
+
+
+* Each Booster Pack catalog release will contain the complete set of Booster Pack zip assets that are currently supported for that catalog version, so users can go to one release to find every supported pack.
+* Each Booster Pack catalog release will include a top-level `booster-pack-catalog.json` that describes those release contents.
+* Each Booster Pack zip consists of ACFs and a pack-specific `booster-pack-manifest.json` that describes the ACFs for that pack.
+
+
+Until those assets are published, treat these as proposed asset names:
+* `helion-booster-pack.zip`
+* `debug-pack.zip`
+
+
+Each Booster Pack zip should include a pack-specific manifest file, for example `booster-pack-manifest.json`. The release notes, catalog file, and pack manifest are the source of truth for each pack; check them for the intended workload, compiler version and path or compiler stage, GPU target, validation context, and known caveats.
+
+## Using a Booster Pack
+
+The basic workflow is:
+
+1. Run your workload without an ACF and save the baseline result.
+2. Download the Booster Pack from GitHub Releases.
+3. Unzip the pack.
+4. Apply one ACF at a time through the Controls Interface.
+5. Validate correctness against a known-good reference.
+6. Compare performance against the no-ACF baseline.
+7. Keep only candidates that compile, pass correctness, and improve the target workload.
+
+For direct PTXAS usage, pass the ACF with `--apply-controls`:
+
+```bash
+ptxas -v -arch=sm_90a --apply-controls candidate.acf kernel.ptx
+```
+
+For NVCC usage, pass the same option to NVCC:
+
+```bash
+nvcc -arch=sm_100 --apply-controls candidate.acf kernel.cu -o kernel
+```
+
+For Triton, pass the ACF through PTXAS options as shown in the [Triton example](triton_example.md). Make sure you force recompilation where framework caching applies, such as with `TRITON_ALWAYS_COMPILE`.
+
+For Helion, pass the ACF through the official ACF API as shown in the [Softmax Example](https://helionlang.com/examples/acfs/softmax_acf.html). Make sure you force recompilation where framework caching applies.
+
+## Trying Related Workloads
+
+ACFs rarely generalize automatically, but related workloads can sometimes benefit from the same compiler decisions.
+
+If your workload is similar to the workload described in a Booster Pack release, it may be worth testing that pack before running a full search. The safe way to do this is still candidate-by-candidate validation:
+
+* Apply one ACF at a time.
+* Test multiple input shapes where applicable.
+* Compare against a known-good implementation.
+* Use compile and runtime timeouts.
+* Run multiple performance trials if the benchmark is noisy.
+* Record the ACF name, command, compiler path/version, CTK, driver, GPU model, workload shape, and result.
+
+As an example we have applied the Helion Booster Pack to Batch Decode in FlashInfer and we can see that some shapes get considerable benefits from some of the ACFs in the pack:
+
+<figure>
+  <img src="_static/decode_acf_s_curve_summary.svg" alt="FlashInfer Batch Decode - Summary ACF S-curve" style="width: 100%;" />
+  <figcaption>Summary of FlashInfer Batch Decode results across ACF candidates.</figcaption>
+</figure>
+
+For a FlashInfer-specific walkthrough, see [Applying a Booster Pack to FlashInfer](flashinfer_booster.md).
+
+## When to Run a Search Instead
+
+Run your own CompileIQ search if:
+
+* None of the Booster Pack candidates help your workload.
+* Your GPU, CTK, compiler, framework, or workload shape differs materially from the release notes.
+* You need stronger confidence for a specific production workload.
+* You want to co-tune compiler controls with application-level parameters.
+
+Booster Packs are a shortcut when a curated candidate works. They do not replace workload-specific search and validation.

--- a/docs/compilers_overview.md
+++ b/docs/compilers_overview.md
@@ -1,16 +1,28 @@
-# Leveraging CompileIQ with Nvidia Compilers
+# Tuning NVIDIA Compilers
+
+Starting in CUDA Toolkit (CTK) 13.3, NVCC and PTXAS expose a __Controls Interface__ through the `--apply-controls` option. This interface lets you pass an __Advanced Controls File__ (ACF) to the compiler and change the compiler decisions used for that compilation.
+
+CompileIQ uses this interface to generate ACFs for a given workload. In practice, this lets you adapt the compiler to the workload without changing the kernel source. If you want to try curated ACFs before running a full search, see [Booster Packs](booster_packs.md).
+
+## What an ACF Changes
+
+An ACF changes compiler optimization and control decisions for a compilation. It does not change your kernel source. The practical result can be different SASS, different register allocation, different scheduling choices, different memory behavior, or a different compile outcome.
+
+This is what we mean by changing the compiler heuristics profile for a workload: the source stays fixed, but the compiler decisions can change.
+
+## Leveraging the Controls Interface with CompileIQ
 
 One of CompileIQ’s key features is support for NVIDIA compiler tuning. Currently supported compilers are NVCC and PTXAS.
 
 To enable compiler tuning, you must first download the search space from [our repository](https://github.com/NVIDIA/CompileIQ/blob/main/assets) or leverage `compileiq.search_spaces.compilers.py` to automatically pull.
 
-These files contain search-space information for CompileIQ to sample from. Each file includes a curated set of compiler knobs that modify compiler behavior and interact with each other, producing different SASS.
+These files contain search-space information for CompileIQ to sample from. Each file includes a curated set of compiler controls that modify compiler behavior and interact with each other, producing different SASS.
 
-We call a sample of these search spaces an __Advanced Controls File__ (ACF).
+> Each sample of the Search-Space makes an ACF
 
 ## Safety & correctness (read this first)
 
-Before we dive into an example, here are the most important things to know about tuning compiler knobs.
+Before we dive into an example, this section outlines the most important things to know about tuning compiler controls.
 
 > __TL;DR__: Treat ACFs as *per-kernel* and *per-environment*. Expect failures. Add timeouts, correctness checks, and good logging.
 
@@ -27,7 +39,7 @@ In rare cases, improvements found in one search extend to other code and GPUs, b
 
 ### Expect failures (and handle them)
 
-Because ACFs affect compiler behavior—and because the search space has an intractable number of combinations and dependencies—__applying ACFs may trigger compilation failures, compile hangs, numeric instability, and other unexpected behaviors__. Your objective function should handle these gracefully to avoid crashing the search.
+Because ACFs affect compiler behavior, and because the search space has an intractable number of combinations and dependencies, __applying ACFs may trigger compilation failures, compile hangs, numeric instability, and other unexpected behaviors__. Your objective function should handle these gracefully to avoid crashing the search.
 
 Common failure modes include:
 

--- a/docs/flashinfer_booster.md
+++ b/docs/flashinfer_booster.md
@@ -1,0 +1,158 @@
+# Applying a Booster Pack to FlashInfer
+
+This page shows how to try the Helion Booster Pack on FlashInfer's `BatchDecodeWithPagedKVCacheWrapper` benchmark.
+
+The Booster Pack contains pre-made Advanced Controls Files (ACFs). Each ACF changes compiler decisions through the NVIDIA Controls Interface, without changing the FlashInfer source code. Even though this Booster Pack was generated using Helion kernels, some cases of FlashInfer do benefit from the same ACFs.
+
+> Booster Packs are not a replacement for validation. ACFs can cause compilation errors, hangs, crashes, wrong answers, regressions, or noisy measurements.
+
+## Prerequisites
+
+Use an environment that matches the Booster Pack release notes and manifest. At minimum, check:
+
+* GPU model and compute capability.
+* CUDA Toolkit version.
+* `nvcc` and `ptxas` paths.
+* FlashInfer version or source checkout.
+* Benchmark command and input shape.
+
+For this workflow, use CTK 13.3 or newer so `nvcc` and `ptxas` support the Controls Interface.
+
+```bash
+export CUDA_HOME=/path/to/cuda
+export CUDA_PATH="$CUDA_HOME"
+export FLASHINFER_NVCC="$CUDA_HOME/bin/nvcc"
+export FLASHINFER_CUDA_ARCH_LIST=10.0a
+export FLASHINFER_NO_DOWNLOAD=1
+export PATH="$CUDA_HOME/bin:$PATH"
+```
+
+Verify the compiler paths before running the benchmark:
+
+```bash
+"$FLASHINFER_NVCC" --version
+"$CUDA_HOME/bin/ptxas" --version
+"$CUDA_HOME/bin/ptxas" --help | grep apply-controls
+```
+
+If your toolkit, GPU, or FlashInfer setup differs from the release notes, you can still test the pack, but treat the result as a new validation target.
+
+## Use Source FlashInfer
+
+Use a FlashInfer source checkout or an editable install so the benchmark compiles kernels in your current environment. Avoid prebuilt kernel caches when evaluating ACFs.
+
+Confirm which FlashInfer package Python imports:
+
+```bash
+python - <<'PY'
+import flashinfer
+print(flashinfer.__file__)
+PY
+```
+
+If your environment includes prebuilt FlashInfer cache packages, make sure they are not being used for this experiment:
+
+```bash
+python - <<'PY'
+import importlib.util
+for name in ["flashinfer_cubin", "flashinfer_jit_cache"]:
+    spec = importlib.util.find_spec(name)
+    print(name, spec)
+    if spec is not None:
+      raise RuntimeError(f"Package {name} is present in the environment. Please remove it before proceeding.")
+PY
+```
+
+For a clean ACF test, both cache package checks should print `None`.
+
+## Download the Pack
+
+Download the Helion booster pack `.zip` from the most recent booster pack release in the [CompileIQ GitHub Releases page](https://github.com/NVIDIA/CompileIQ/releases), then unzip it into your workspace.
+
+```bash
+unzip helion-booster-pack.zip -d helion-booster-pack
+```
+
+Read the manifest before running the candidates. The manifest and release notes are the source of truth for the intended workload, compiler version, GPU target, validation context, and known caveats.
+
+## Run a Baseline
+
+Run the benchmark once without an ACF. Save the command, environment, and result; this is the number every candidate must beat.
+
+```bash
+unset FLASHINFER_EXTRA_CUDAFLAGS
+
+python benchmarks/flashinfer_benchmark.py \
+  --routine BatchDecodeWithPagedKVCacheWrapper \
+  --backends fa2 \
+  --page_size 16 \
+  --batch_size 1 \
+  --s_qo 1 \
+  --s_kv 128 \
+  --num_qo_heads 8 \
+  --num_kv_heads 8 \
+  --head_dim_qk 128 \
+  --head_dim_vo 128 \
+  --q_dtype bfloat16
+```
+
+If your benchmark has meaningful variability, run several trials and compare candidates against the aggregate baseline instead of a single run.
+
+## Apply One ACF
+
+Choose one ACF from the unzipped pack and pass it to PTXAS through NVCC:
+
+```bash
+export ACF_FILE=/path/to/helion-booster-pack/candidate.acf
+export FLASHINFER_EXTRA_CUDAFLAGS="--ptxas-options=--apply-controls=$ACF_FILE"
+
+python benchmarks/flashinfer_benchmark.py \
+  --routine BatchDecodeWithPagedKVCacheWrapper \
+  --backends fa2 \
+  --page_size 16 \
+  --batch_size 1 \
+  --s_qo 1 \
+  --s_kv 128 \
+  --num_qo_heads 8 \
+  --num_kv_heads 8 \
+  --head_dim_qk 128 \
+  --head_dim_vo 128 \
+  --q_dtype bfloat16
+```
+
+Apply only one ACF per run. If the benchmark fails to compile, hangs, crashes, returns wrong answers, or regresses, reject that candidate and move to the next one.
+
+## Force Recompilation
+
+Framework and benchmark caches can hide whether an ACF was actually applied. Use a fresh workspace or clear the relevant cache before each candidate.
+
+For FlashInfer experiments, make sure the benchmark recompiles kernels after changing `FLASHINFER_EXTRA_CUDAFLAGS`. If you cannot prove recompilation happened, do not trust the measurement.
+
+## Validate the Result
+
+Treat correctness validation as part of the benchmark workflow. Compare each candidate against a known-good reference, and test multiple input shapes when those shapes matter for your workload.
+
+Record enough information to reproduce the result:
+
+* ACF filename.
+* Manifest and release version.
+* Benchmark command.
+* GPU model and driver.
+* CTK version.
+* `nvcc` and `ptxas` paths and versions.
+* FlashInfer version or commit.
+* Input shape.
+* Baseline result.
+* Candidate result.
+* Correctness status.
+
+Keep the ACF only if it compiles, passes correctness checks, and improves the no-ACF baseline.
+
+## Results
+
+Below we show comprehensive results for different cases of `BatchDecodeWithPagedKVCacheWrapper`. This data was generated on a B200 machine.
+
+<figure>
+  <img src="_static/decode_acf_s_curve_full.svg" alt="FlashInfer Batch Decode ACF S-curve" style="width: 100%;" />
+  <figcaption>FlashInfer <code>BatchDecodeWithPagedKVCacheWrapper</code> results across ACF candidates.</figcaption>
+</figure>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,19 +13,12 @@ CompileIQ Documentation
 .. toctree::
    :hidden:
    :maxdepth: 3
-   :caption: More Examples
-
-   xgboost
-   experiment_tracking
-
-.. toctree::
-   :hidden:
-   :maxdepth: 3
    :caption: Nvidia Compiler Tuning
 
    compilers_overview
-   nvcc_example
+   booster_packs
    ptx_spill_example
+   nvcc_example
    triton_example
 
 .. toctree::
@@ -35,6 +28,15 @@ CompileIQ Documentation
 
    workers
    normalization
+
+.. toctree::
+   :hidden:
+   :maxdepth: 3
+   :caption: More Examples
+
+   xgboost
+   experiment_tracking
+   flashinfer_booster
 
 .. toctree::
    :hidden:

--- a/docs/nvcc_example.md
+++ b/docs/nvcc_example.md
@@ -1,12 +1,12 @@
-# Tuning NVCC compiler knobs for a CUDA kernel
+# Tuning NVCC compiler controls for a CUDA kernel
 
-In this section, we walk through optimizing the runtime of a CUDA reduction kernel by tuning NVCC compiler knobs with CompileIQ.
+In this section, we walk through optimizing the runtime of a CUDA reduction kernel by tuning NVCC compiler controls with CompileIQ.
 
 > The example code can be found [in our repo here](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvcc_example/optimize_reduction.py).
 
 ## CUDA Reduction Example
 
-This example uses a self-contained CUDA reduction kernel (`reduction.cu`) that sums 64M integers using shared memory and warp shuffle. CompileIQ tunes the NVCC compiler knobs via `--apply-controls` to minimize runtime.
+This example uses a self-contained CUDA reduction kernel (`reduction.cu`) that sums 64M integers using shared memory and warp shuffle. CompileIQ tunes the NVCC compiler controls via `--apply-controls` to minimize runtime.
 
 What you'll need:
 

--- a/docs/ptx_spill_example.md
+++ b/docs/ptx_spill_example.md
@@ -1,6 +1,6 @@
-# First steps to apply compiler knobs
+# First steps to apply compiler controls
 
-In this section, we will walk you through how to set up your first search to tune PTXAS compiler knobs.
+In this section, we will walk you through how to set up your first search to tune PTXAS compiler controls.
 
 > The example code and supporting files can be found [in our repo here](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/ptxas_example/ptx_spill.py).
 
@@ -8,7 +8,7 @@ In this section, we will walk you through how to set up your first search to tun
 
 In this example, we will use a PTX kernel that contains register spill issues. Register spilling occurs when there aren’t enough GPU registers to hold active variables. These variables are temporarily moved to slower memory and then loaded back when needed, which can slow performance due to increased memory traffic.
 
-Our end goal is to run a search that tunes PTXAS compiler knobs and reduces register spilling to (or close to) zero.
+Our end goal is to run a search that tunes PTXAS compiler controls and reduces register spilling to (or close to) zero.
 
 What you’ll need:
 
@@ -85,7 +85,7 @@ PTX_SOURCE_PATH = "w8_spill.ptx"
 
 def objective(config):
     """
-    This function will receive a string blob that contains the compiler knobs configuration.
+    This function will receive a string blob that contains the compiler controls configuration.
     It will save it to a temporary file, and then call ptxas with that configuration to compile
     the PTX file. Finally, it will parse the output of ptxas to extract the number of register spills.
     """
@@ -168,15 +168,15 @@ def main():
 
     best = results.get_best_result()
     logger.info(f"Best spill found: {best['score_1']}")
-    save_compiler_config("best_compiler_knobs.acf", best["params"])
+    save_compiler_config("best_compiler_controls.acf", best["params"])
 ```
 
 The structure is mostly the same as other CompileIQ examples. Here we use the default worker (multiprocess), which executes 4 objective evaluations in parallel.
 
-We save the best solution to `best_compiler_knobs.acf`. You can call `ptxas` from the command line to reproduce the result:
+We save the best solution to `best_compiler_controls.acf`. You can call `ptxas` from the command line to reproduce the result:
 
 ```bash
-ptxas -v -arch=sm_90a --apply-controls best_compiler_knobs.acf w8_spill.ptx
+ptxas -v -arch=sm_90a --apply-controls best_compiler_controls.acf w8_spill.ptx
 ```
 
 Expected output:
@@ -190,8 +190,14 @@ ptxas info    : Used 240 registers, used 1 barriers
 ptxas info    : Compile time = 369.596 ms
 ```
 
-## Other compilers
+## Other compilers and environments
 
-Our current support extends to PTXAS and NVCC. For NVCC, nvidia also offer a cli option called `--apply-controls` to apply ACF files through `nvcc`.
+Our current support extends to PTXAS and NVCC. This option offers the user to tune standalone NVCC, standalone PTXAS or a search space with both combined. 
 
-This option offers the user to tune standalone NVCC, standalone PTXAS or a search space with both combined. PTXAS ACFs are automatically detected and forwarded to PTXAS.
+Other environments like Triton and Helion provide facilities to inject ACFs on the compilation flow, and even to select ACFs for specific kernels or inputs. 
+
+Consult the respective documentations or follow our examples in the next pages of this guide:
+
+* [Tuning NVCC compiler controls](nvcc_example.md)
+* [Tuning PTXAS controls in your Triton kernel](triton_example.md)
+

--- a/docs/triton_example.md
+++ b/docs/triton_example.md
@@ -1,4 +1,4 @@
-# Tuning PTX knobs in your Triton kernel
+# Tuning PTXAS controls in your Triton kernel
 
 In this section, we will build on an existing Triton tutorial kernel and apply PTXAS ACFs.
 
@@ -104,7 +104,7 @@ This objective is following all guidelines from our [Safety Section](compilers_o
 
 #### Expanding the search to different matrix sizes
 
-In this example, we tune PTXAS knobs for a specific matrix size of 512×512. If you want to support multiple sizes, you have a few options:
+In this example, we tune PTXAS controls for a specific matrix size of 512×512. If you want to support multiple sizes, you have a few options:
 
 * Perform one different search for each size
 * Benchmark and validate all matrix sizes inside the objective and return the mean, or only return a score if the ACF showed gains on most or all of the benchmarks

--- a/examples/compilers/ptxas_example/README.md
+++ b/examples/compilers/ptxas_example/README.md
@@ -28,4 +28,4 @@ python ptx_spill.py --arch sm_90a
 
 - `ptx_spill.py` - Optimization script
 - `w8_spill.ptx` - PTX file with register pressure
-- `best_compiler_knobs.acf` - Best config (generated)
+- `best_compiler_controls.acf` - Best config (generated)

--- a/examples/compilers/ptxas_example/ptx_spill.py
+++ b/examples/compilers/ptxas_example/ptx_spill.py
@@ -74,7 +74,7 @@ def main():
     # Save best result
     best = results.get_best_result()
     print(f"Best spill bytes: {best['score_1']}")
-    save_compiler_config("best_compiler_knobs.acf", best["params"])
+    save_compiler_config("best_compiler_controls.acf", best["params"])
 
 
 if __name__ == "__main__":

--- a/examples/compilers/triton_example/README.md
+++ b/examples/compilers/triton_example/README.md
@@ -16,7 +16,7 @@ python triton_ptx.py
 
 Searches both Triton configs AND PTXAS controls together:
 - **User space**: Block sizes, warps, stages
-- **Compiler space**: PTXAS internal knobs
+- **Compiler space**: PTXAS compiler controls
 
 ```bash
 python mixed_triton.py


### PR DESCRIPTION
## Description

Adds documentation pages to Booster Packs
Re-arranges some docs pages for better story telling around compiler tuning

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/CompileIQ/user_guide/contribution_guide.html).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.

## Test plan

local build of docs 

## Bug fix
NA

## New feature / enhancement
NA