### PR TITLE
Add NVBench compiler optimization example and benchmarking docs

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,0 +1,75 @@
+# Benchmarking Approaches
+
+CompileIQ's compiler tuning requires accurate, repeatable kernel timing.
+Different measurement tools suit different workflows. This page summarizes
+the approaches used across CompileIQ's examples and when to choose each one.
+
+## NVBench (C++ CUDA kernels)
+
+[NVBench](https://github.com/NVIDIA/nvbench) is a CUDA kernel benchmarking
+library that provides cold measurements (L2 cache flushed between samples),
+entropy-based convergence, and full timing distributions.
+
+NVBench is the recommended tool for benchmarking C++ CUDA kernels. See the
+[NVBench optimization example](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvbench_example/)
+for a complete walkthrough.
+
+**When to use**: C++ CUDA kernels where you want statistically rigorous,
+cache-cold measurements without writing your own timing harness.
+
+**Key features**:
+
+- L2 cache flushed between samples for cold measurements
+- Entropy-based stopping criterion adapts sample count to noise
+- Full sample distribution available for custom aggregation (P75, median, etc.)
+- Automatic discarding of measurements when thermal throttling is detected
+
+## Triton `do_bench` (Python / Triton kernels)
+
+Triton's built-in `triton.testing.do_bench` provides a convenient Python-native
+benchmarking function with configurable warmup and repetitions. It is used in
+the [Triton optimization example](triton_example.md).
+
+```python
+runtime = triton.testing.do_bench(
+    lambda: matmul(a, b, acf_file),
+    warmup=100,
+    rep=1000,
+    return_mode="mean",
+)
+```
+
+**When to use**: Triton kernels or any GPU kernel callable from Python. Simple
+to integrate and avoids compilation of a separate benchmark binary.
+
+## Manual CUDA Events (simple C++ timing)
+
+For lightweight benchmarking without external dependencies, `cudaEventRecord`
+and `cudaEventElapsedTime` can bracket a kernel launch. This approach is used
+in the [NVCC optimization example](nvcc_example.md).
+
+**When to use**: Self-contained prototype CUDA programs where you want minimal
+dependencies and full control over warmup iterations. For production use-cases
+use of NVBench is strongly recommended.
+
+## Choosing a benchmarking approach
+
+| Approach | Language | Cache-cold | Statistical rigor | Setup complexity |
+|----------|----------|------------|-------------------|------------------|
+| NVBench | C++ | Yes | High (entropy-driven) | Medium (requires NVBench install) |
+| `do_bench` | Python | No | Medium (fixed warmup + reps) | Low (part of Triton) |
+| CUDA Events | C++ | No | Basic (manual runs) | Low (no dependencies) |
+
+## Profiling with NVIDIA Nsight Compute
+
+Benchmarking measures *how long* a kernel takes. **Profiling** answers
+*why* it takes that long -- identifying memory bottlenecks, occupancy
+limits, instruction mix, and warp stalls.
+
+[NVIDIA Nsight Compute](https://developer.nvidia.com/nsight-compute)
+is the recommended profiling tool for CUDA kernels. While CompileIQ
+examples focus on benchmarking (timing is the optimization objective),
+Nsight Compute is invaluable for understanding *what* to optimize
+before or after a CompileIQ search.
+
+> Nsight Compute integration examples are planned for a future release.

--- a/docs/compilers_overview.md
+++ b/docs/compilers_overview.md
@@ -61,5 +61,6 @@ Each example below follows this pattern: define an objective function, fetch a c
 | [NVCC reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvcc_example/) | NVCC | Runtime (ms) | [NVCC example](nvcc_example.md) |
 | [PTXAS spill reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/ptxas_example/) | PTXAS | Spill bytes | [PTXAS example](ptx_spill_example.md) |
 | [Triton matmul](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/triton_example/) | PTXAS via Triton | Runtime (ms) | [Triton example](triton_example.md) |
+| [NVBench reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvbench_example/) | PTXAS via NVCC | Runtime (P75, NVBench) | [Benchmarking](benchmarking.md) |
 
 The PTXAS example is the simplest starting point — it only requires `ptxas` and runs on CPU (no GPU needed). The NVCC and Triton examples require a GPU to measure runtime.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ CompileIQ Documentation
    nvcc_example
    ptx_spill_example
    triton_example
+   benchmarking
 
 .. toctree::
    :hidden:

--- a/examples/compilers/nvbench_example/README.md
+++ b/examples/compilers/nvbench_example/README.md
@@ -1,0 +1,85 @@
+# NVBench Optimization Example
+
+Optimize a CUDA reduction kernel with CompileIQ using NVBench for accurate
+benchmarking and the PTXAS search space for compiler control tuning.
+
+## Why NVBench?
+
+NVBench provides statistically rigorous and accurate kernel runtime measurements
+and should be preferred to naive use of cudaEvent timing (as used in
+`../nvcc_example/`):
+
+- **Cold measurements** — L2 cache is flushed between samples, preventing
+  artificially warm cache from skewing results
+- **Entropy-based convergence** — automatically collects enough samples until
+  the timing distribution stabilizes, rather than using a fixed iteration count
+- **Throttling detection** — automatically discards measurements when thermal
+  throttling is detected
+- **Access to full sample** — allows implementing custom metrics, e.g.
+  75-percentile, which are more robust and less sensitive to outliers than
+  the mean
+
+## Why PTXAS Controls on CUDA Source?
+
+The existing `ptxas_example/` applies PTXAS controls to pre-compiled `.ptx`
+files. This example shows that PTXAS controls also work on `.cu` source files
+compiled through `nvcc` — using `-Xptxas --apply-controls=<file>` to forward
+controls to the internal PTXAS invocation. This opens up PTXAS-level tuning
+for any CUDA kernel without requiring a separate PTX compilation step.
+
+## Prerequisites
+
+- CUDA 13.3+
+- NVBench (built and installed — see below)
+- Blackwell GPU (sm_100) or adjust `--arch`
+- `pip install compileiq`
+
+### NVBench Installation
+
+```bash
+git clone https://github.com/NVIDIA/nvbench.git
+cd nvbench
+cmake -B build -G Ninja --preset nvbench-ci \
+  -DCMAKE_INSTALL_PREFIX=$(pwd)/build/nvbench_install \
+  -DCMAKE_CUDA_COMPILER=$(which nvcc) \
+  -DCMAKE_CUDA_ARCHITECTURES=100 \
+  -DNVBench_ENABLE_CUPTI=OFF \
+  -DNVBench_ENABLE_NVML=OFF
+cmake --build build --target install
+export NVBENCH_PATH=$(pwd)/build/nvbench_install
+```
+
+## Quick Start
+
+```bash
+# Run optimization (auto-downloads PTXAS search space)
+python optimize_reduction.py
+
+# Benchmark with optimized config
+python optimize_reduction.py --benchmark-only \
+    --nvcc-options "-Xptxas --apply-controls=best_reduction.acf"
+```
+
+## Options
+
+```bash
+# Custom GPU architecture
+python optimize_reduction.py --arch sm_90a
+
+# More thorough search
+python optimize_reduction.py --generations 20 --pool-size 30
+
+# Smaller problem size (2^22 elements)
+python optimize_reduction.py --elements-pow2 22
+
+# Standalone benchmark (no optimization)
+python optimize_reduction.py --benchmark-only --arch sm_100
+```
+
+## Files
+
+- `reduction_bench.cu` — NVBench-instrumented CUDA reduction kernel
+- `optimize_reduction.py` — Optimization and benchmarking script
+- `nvbench_utils.py` — NVBench result parsing utilities
+- `best_reduction.acf` — Best PTXAS config (generated)
+- `optimization_results.csv` — Search history (generated)

--- a/examples/compilers/nvbench_example/nvbench_utils.py
+++ b/examples/compilers/nvbench_example/nvbench_utils.py
@@ -1,0 +1,56 @@
+"""
+NVBench result parsing utilities.
+
+This module provides helpers for parsing NVBench JSON output. It is kept
+separate from the optimization script so that it can be updated independently
+— for example, when the ``cuda-bench`` Python package
+(https://pypi.org/project/cuda-bench/) provides equivalent functionality.
+"""
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def parse_nvbench_result(json_path: Path) -> float | None:
+    """Parse NVBench --jsonbin output, return P75 latency (seconds).
+
+    Reads the JSON file, finds the cold sample times binary file,
+    and computes the 75th percentile of the timing distribution.
+
+    Note: This function returns the P75 of the *first* cold sample data
+    found across all benchmarks and states. It assumes the JSON corresponds
+    to a single benchmark run with a single set of parameters (e.g., one
+    value in the "Elements" axis). For multi-benchmark or multi-axis runs,
+    only the first matching measurement is returned and all others are
+    silently ignored. Callers should ensure the NVBench invocation targets
+    a single benchmark/parameter combination (e.g., via
+    ``-b reduction -a "Elements[pow2]=26"``).
+    """
+    try:
+        with open(json_path) as f:
+            root = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+
+    for bench in root.get("benchmarks", []):
+        for state in bench.get("states", []):
+            if state.get("is_skipped", False):
+                continue
+            for summary in state.get("summaries", []):
+                if summary.get("tag") != "nv/json/bin:nv/cold/sample_times":
+                    continue
+                data = {d["name"]: d["value"] for d in summary.get("data", [])}
+                bin_path = data.get("filename")
+                n_samples = int(data.get("size", 0))
+                if not bin_path or n_samples == 0:
+                    continue
+                try:
+                    samples = np.fromfile(bin_path, dtype="<f4")
+                except FileNotFoundError:
+                    continue
+                if len(samples) != n_samples:
+                    continue
+                return float(np.percentile(samples, 75))
+    return None

--- a/examples/compilers/nvbench_example/optimize_reduction.py
+++ b/examples/compilers/nvbench_example/optimize_reduction.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""
+CompileIQ NVBench Example: Optimize CUDA reduction kernel with PTXAS controls.
+
+Uses NVBench for statistically rigorous benchmarking and CompileIQ's
+evolutionary search over the PTXAS search space to find optimal compiler
+configurations for a CUDA reduction kernel.
+
+Usage:
+    python optimize_reduction.py --nvbench-path /path/to/nvbench/install
+
+    # Benchmark-only (no optimization):
+    python optimize_reduction.py --nvbench-path /path/to/nvbench/install --benchmark-only
+
+    # With saved config:
+    python optimize_reduction.py --nvbench-path /path/to/nvbench/install \
+        --benchmark-only --nvcc-options "--apply-controls best_reduction.acf"
+"""
+
+import argparse
+import os
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import tempfile
+from pathlib import Path
+
+from compileiq.ciq import Search, SearchConfiguration
+from compileiq.search_spaces.compilers import PtxasSearchSpace
+from compileiq.types import INVALID_SCORE, ProblemType
+from compileiq.utils.helpers import save_compiler_config
+from nvbench_utils import parse_nvbench_result
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+REDUCTION_CU = SCRIPT_DIR / "reduction_bench.cu"
+
+
+# ---------------------------------------------------------------------------
+# CUDA / NVBench path discovery
+# ---------------------------------------------------------------------------
+
+def get_cuda_paths():
+    """Find CUDA installation from nvcc in PATH."""
+    nvcc_path = shutil.which("nvcc")
+    if not nvcc_path:
+        raise RuntimeError("nvcc not found in PATH")
+    cuda_root = Path(nvcc_path).parent.parent
+    cuda_lib = cuda_root / "lib64"
+    if not cuda_lib.exists():
+        cuda_lib = cuda_root / "lib"
+    return cuda_root, cuda_lib
+
+
+def get_nvbench_paths(nvbench_path: Path):
+    """Locate NVBench include, lib, and main.cu.o from install directory.
+
+    Returns (include_dir, lib_dir, main_obj) or raises RuntimeError.
+    """
+    nvbench_path = Path(nvbench_path)
+    include_dir = nvbench_path / "include"
+    lib_dir = nvbench_path / "lib"
+    main_obj = lib_dir / "objects-Release" / "nvbench.main" / "main.cu.o"
+
+    if not include_dir.exists():
+        raise RuntimeError(f"NVBench include dir not found: {include_dir}")
+    if not lib_dir.exists():
+        raise RuntimeError(f"NVBench lib dir not found: {lib_dir}")
+    if not main_obj.exists():
+        raise RuntimeError(
+            f"NVBench main.cu.o not found: {main_obj}\n"
+            "Ensure NVBench was built with cmake --build ... --target install"
+        )
+    return include_dir, lib_dir, main_obj
+
+
+# ---------------------------------------------------------------------------
+# Build and run
+# ---------------------------------------------------------------------------
+
+def build_benchmark(
+    arch: str,
+    nvbench_path: Path,
+    tmpdir: str,
+    config_file: Path = None,
+    extra_nvcc_opts: list = None,
+) -> Path | None:
+    """Compile reduction_bench.cu linked with NVBench.
+
+    Returns path to the compiled executable, or None on failure.
+    """
+    cuda_root, cuda_lib = get_cuda_paths()
+    nvcc = str(cuda_root / "bin" / "nvcc")
+    include_dir, lib_dir, main_obj = get_nvbench_paths(nvbench_path)
+
+    exe = Path(tmpdir) / "reduction_bench"
+
+    flags = [
+        f"-arch={arch}",
+        "-O3", "-std=c++17", "-DNDEBUG",
+        f"-I{include_dir}",
+        f"-L{lib_dir}",
+        f"-Xlinker=-rpath,{lib_dir}",
+    ]
+    if config_file:
+        # Forward controls to ptxas only (not libnvvm) via -Xptxas
+        flags += ["-Xptxas", f"--apply-controls={config_file}"]
+    if extra_nvcc_opts:
+        flags += extra_nvcc_opts
+
+    env = os.environ.copy()
+    env["LIBRARY_PATH"] = f"{cuda_lib}:{env.get('LIBRARY_PATH', '')}"
+    env["LD_LIBRARY_PATH"] = f"{cuda_lib}:{lib_dir}:{env.get('LD_LIBRARY_PATH', '')}"
+
+    cmd = [
+        nvcc, *flags,
+        str(REDUCTION_CU),
+        str(main_obj),
+        "-lnvbench", "-lcudart_static", "-lcuda",
+        "-o", str(exe),
+    ]
+
+    try:
+        subprocess.run(cmd, env=env, capture_output=True, check=True, timeout=120)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        stderr = getattr(e, "stderr", b"")
+        if stderr:
+            print(f"Build failed: {stderr.decode(errors='replace')[:500]}")
+        return None
+
+    return exe
+
+
+def run_nvbench(
+    exe_path: Path, elements_pow2: int, tmpdir: str, timeout: int = 360,
+) -> float | None:
+    """Run the NVBench benchmark and return P75 latency (seconds).
+
+    Returns None on failure or timeout.
+    """
+    result_path = os.path.join(tmpdir, "result.json")
+    cmd = [
+        str(exe_path), "-d", "0", "-b", "reduction",
+        "-a", f"Elements[pow2]={elements_pow2}",
+        "--no-batch", "--stopping-criterion", "entropy",
+        "--jsonbin", result_path,
+    ]
+
+    try:
+        p = subprocess.Popen(
+            cmd, start_new_session=True,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        p.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(p.pid), signal.SIGTERM)
+        print("NVBench benchmark timed out")
+        return None
+
+    if p.returncode != 0:
+        return None
+
+    return parse_nvbench_result(Path(result_path))
+
+
+# ---------------------------------------------------------------------------
+# Modes
+# ---------------------------------------------------------------------------
+
+def run_benchmark_only(args):
+    """Benchmark-only mode: build with optional nvcc options and report timing."""
+    extra_opts = shlex.split(args.nvcc_options) if args.nvcc_options else None
+
+    with tempfile.TemporaryDirectory(prefix="ciq_nvbench_") as tmpdir:
+        exe = build_benchmark(
+            args.arch, args.nvbench_path, tmpdir, extra_nvcc_opts=extra_opts,
+        )
+        if not exe:
+            print("Build failed")
+            exit(1)
+
+        score = run_nvbench(exe, args.elements_pow2, tmpdir)
+        if score is None:
+            print("Benchmark failed")
+            exit(1)
+
+        print(f"P75 latency: {score * 1000:.4f} ms  ({score:.6f} s)")
+
+
+def run_optimization(args, cuda_version: str):
+    """Run evolutionary optimization to find best PTXAS compiler config."""
+    nvbench_path = args.nvbench_path
+
+    # Run baseline (no compiler controls)
+    print("Running baseline...")
+    with tempfile.TemporaryDirectory(prefix="ciq_nvbench_base_") as tmpdir:
+        exe = build_benchmark(args.arch, nvbench_path, tmpdir)
+        if not exe:
+            print("Baseline build failed")
+            return 1
+        baseline = run_nvbench(exe, args.elements_pow2, tmpdir)
+
+    if baseline is None:
+        print("Baseline benchmark failed")
+        return 1
+    print(f"Baseline P75: {baseline * 1000:.4f} ms\n")
+
+    # Objective function: compile with PTXAS config, measure with NVBench
+    def objective(config_str: str) -> float:
+        with tempfile.TemporaryDirectory(prefix="ciq_nvbench_") as tmpdir:
+            acf_path = Path(tmpdir) / "controls.acf"
+            save_compiler_config(str(acf_path), config_str)
+
+            exe = build_benchmark(args.arch, nvbench_path, tmpdir, config_file=acf_path)
+            if not exe:
+                return INVALID_SCORE
+
+            score = run_nvbench(exe, args.elements_pow2, tmpdir)
+            if score is None:
+                return INVALID_SCORE
+
+            return score
+
+    # Configure and run search
+    search_space = args.search_space or PtxasSearchSpace(version=cuda_version)
+    config = SearchConfiguration(
+        problem_type=ProblemType.MIN,
+        generations=args.generations,
+        pool_size=args.pool_size,
+    )
+    tuner = Search(
+        objective_function=objective,
+        search_space=search_space,
+        search_config=config,
+        dump_results=SCRIPT_DIR / "optimization_results.csv",
+    )
+
+    print(f"Starting optimization ({args.generations} generations, pool={args.pool_size})...")
+    print("Using PtxasSearchSpace with NVBench measurement (P75 latency)\n")
+    results = tuner.start(num_workers=1)
+    best = results.get_best_result()
+
+    # Report results
+    if best:
+        best_time = best.get("score_1", best.get("score"))
+        speedup = baseline / best_time if best_time > 0 else 0
+
+        print(f"\nBaseline:  {baseline * 1000:.4f} ms")
+        print(f"Optimized: {best_time * 1000:.4f} ms")
+        print(f"Speedup:   {speedup:.2f}x")
+
+        # Save best config
+        config_path = SCRIPT_DIR / "best_reduction.acf"
+        save_compiler_config(str(config_path), best["params"])
+        print(f"\nConfig saved: {config_path}")
+        print(f"Usage: nvcc -Xptxas --apply-controls={config_path} -arch={args.arch} ...")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="CompileIQ NVBench optimization with PTXAS controls"
+    )
+    parser.add_argument("--arch", default="sm_100",
+                        help="GPU architecture (default: sm_100)")
+    parser.add_argument("--nvbench-path", type=Path,
+                        default=os.environ.get("NVBENCH_PATH"),
+                        help="NVBench install directory (or set NVBENCH_PATH env var)")
+    parser.add_argument("--elements-pow2", type=int, default=26,
+                        help="Problem size as power of 2 (default: 26, i.e. 2^26)")
+
+    # Optimization args
+    parser.add_argument("--generations", type=int, default=10,
+                        help="Search generations (default: 10)")
+    parser.add_argument("--pool-size", type=int, default=15,
+                        help="Population size (default: 15)")
+    parser.add_argument("--search-space", type=Path, default=None,
+                        help="Local search space file (skip auto-download)")
+
+    # Benchmark-only args
+    parser.add_argument("--benchmark-only", action="store_true",
+                        help="Skip optimization, just benchmark")
+    parser.add_argument("--nvcc-options", default="",
+                        help="Additional NVCC options (benchmark-only mode)")
+    args = parser.parse_args()
+
+    # Validate NVBench path
+    if not args.nvbench_path:
+        parser.error(
+            "--nvbench-path is required (or set NVBENCH_PATH environment variable)"
+        )
+
+    # Check CUDA version
+    version_output = subprocess.run(
+        ["nvcc", "--version"], capture_output=True, text=True, check=True
+    ).stdout
+    cuda_version = re.search(r"release (\d+\.\d+),", version_output).group(1)
+    assert float(cuda_version) >= 13.3, "CompileIQ requires CUDA 13.3+"
+
+    if args.benchmark_only:
+        run_benchmark_only(args)
+    else:
+        run_optimization(args, cuda_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/compilers/nvbench_example/reduction_bench.cu
+++ b/examples/compilers/nvbench_example/reduction_bench.cu
@@ -1,0 +1,93 @@
+/*
+ * NVBench-instrumented CUDA reduction benchmark for CompileIQ optimization.
+ *
+ * Reduction using cub::BlockReduce, measured by NVBench instead of manual
+ * cudaEvent timing. NVBench provides:
+ *   - Cold measurements (L2 cache flushed between samples)
+ *   - Entropy-based convergence (adapts sample count to noise)
+ *   - Statistical rigor (full timing sample distribution)
+ *
+ * Build (requires NVBench installation):
+ *   nvcc -O3 -std=c++17 -arch=sm_100 reduction_bench.cu \
+ *     -I $NVBENCH_PATH/include -L $NVBENCH_PATH/lib \
+ *     -Xlinker=-rpath,$NVBENCH_PATH/lib \
+ *     -lnvbench -lcudart_static -lcuda \
+ *     $NVBENCH_PATH/lib/objects-Release/nvbench.main/main.cu.o \
+ *     -o reduction_bench
+ *
+ * Usage:
+ *   ./reduction_bench -d 0 -b reduction -a "Elements[pow2]=26" \
+ *     --no-batch --stopping-criterion entropy --jsonbin result.json
+ */
+
+#include <nvbench/nvbench.cuh>
+
+#include <cub/block/block_reduce.cuh>
+#include <cuda_runtime.h>
+#include <thrust/device_vector.h>
+
+#ifndef BLOCK_SIZE
+#define BLOCK_SIZE 256
+#endif
+static constexpr int MAX_BLOCKS = 64;
+
+// Reduction kernel using cub::BlockReduce.
+// Each thread loads multiple elements via grid-stride loop (Brent's theorem)
+// to keep the grid small, then CUB handles the block-wide reduction.
+__global__ void reduce_kernel(const int *__restrict__ g_idata, int *__restrict__ g_odata,
+                              unsigned int n)
+{
+    using BlockReduceT = cub::BlockReduce<int, BLOCK_SIZE>;
+    __shared__ typename BlockReduceT::TempStorage temp_storage;
+
+    unsigned int i = blockIdx.x * BLOCK_SIZE * 2 + threadIdx.x;
+    unsigned int gridSize = BLOCK_SIZE * 2 * gridDim.x;
+
+    // Grid-stride loop: each thread accumulates multiple elements
+    int mySum = 0;
+    while (i < n) {
+        mySum += g_idata[i];
+        if (i + BLOCK_SIZE < n)
+            mySum += g_idata[i + BLOCK_SIZE];
+        i += gridSize;
+    }
+
+    // Block-wide reduction via CUB
+    int blockSum = BlockReduceT(temp_storage).Sum(mySum);
+
+    if (threadIdx.x == 0)
+        g_odata[blockIdx.x] = blockSum;
+}
+
+// NVBench benchmark function
+void reduction_bench(nvbench::state &state)
+{
+    const auto n = static_cast<unsigned int>(state.get_int64("Elements"));
+    if (n == 0) return;
+
+    int numBlocks = (n + (BLOCK_SIZE * 2 - 1)) / (BLOCK_SIZE * 2);
+    if (numBlocks > MAX_BLOCKS) numBlocks = MAX_BLOCKS;
+
+    // Initialize host data with deterministic pattern
+    std::vector<int> h_data(n);
+    for (unsigned int i = 0; i < n; i++)
+        h_data[i] = i & 0xFF;
+
+    // RAII device memory via thrust (no manual cudaMalloc/cudaFree)
+    thrust::device_vector<int> d_idata(h_data.begin(), h_data.end());
+    thrust::device_vector<int> d_odata(numBlocks);
+
+    int *d_idata_ptr = thrust::raw_pointer_cast(d_idata.data());
+    int *d_odata_ptr = thrust::raw_pointer_cast(d_odata.data());
+
+    // NVBench timed region: only the kernel launch is measured.
+    // NVBench handles warm-up, cold measurements, and statistical convergence.
+    state.exec([&](nvbench::launch &launch) {
+        reduce_kernel<<<numBlocks, BLOCK_SIZE, 0, launch.get_stream()>>>(
+            d_idata_ptr, d_odata_ptr, n);
+    });
+}
+
+NVBENCH_BENCH(reduction_bench)
+    .set_name("reduction")
+    .add_int64_power_of_two_axis("Elements", {20, 22, 24, 26});

--- a/examples/compilers/nvbench_example/reduction_bench.cu
+++ b/examples/compilers/nvbench_example/reduction_bench.cu
@@ -80,6 +80,27 @@ void reduction_bench(nvbench::state &state)
     int *d_idata_ptr = thrust::raw_pointer_cast(d_idata.data());
     int *d_odata_ptr = thrust::raw_pointer_cast(d_odata.data());
 
+    // Correctness check (outside the timed region): a miscompiled config could
+    // still benchmark fast — verify the kernel's result against a CPU reference
+    // before accepting any timing. On mismatch, skip the state so the Python
+    // objective returns INVALID_SCORE.
+    reduce_kernel<<<numBlocks, BLOCK_SIZE>>>(d_idata_ptr, d_odata_ptr, n);
+    cudaDeviceSynchronize();
+
+    std::vector<int> h_odata(numBlocks);
+    cudaMemcpy(h_odata.data(), d_odata_ptr, numBlocks * sizeof(int),
+               cudaMemcpyDeviceToHost);
+
+    long long gpu_sum = 0;
+    for (int i = 0; i < numBlocks; i++) gpu_sum += h_odata[i];
+    long long cpu_sum = 0;
+    for (unsigned int i = 0; i < n; i++) cpu_sum += h_data[i];
+
+    if (gpu_sum != cpu_sum) {
+        state.skip("Correctness check failed");
+        return;
+    }
+
     // NVBench timed region: only the kernel launch is measured.
     // NVBench handles warm-up, cold measurements, and statistical convergence.
     state.exec([&](nvbench::launch &launch) {

--- a/examples/compilers/nvcc_example/reduction.cu
+++ b/examples/compilers/nvcc_example/reduction.cu
@@ -1,6 +1,9 @@
 /*
  * Self-contained CUDA reduction benchmark for CompileIQ optimization.
  *
+ * Uses cub::BlockReduce for the block-wide reduction and thrust::device_vector
+ * for RAII device memory management.
+ *
  * Compiles in a single step:
  *   nvcc -O3 -std=c++17 -arch=sm_100 reduction.cu -o reduction
  *
@@ -8,14 +11,15 @@
  *   ./reduction [-n=67108864]
  */
 
-#include <cooperative_groups.h>
+#include <cub/block/block_reduce.cuh>
+#include <cuda_runtime.h>
+#include <thrust/device_vector.h>
+
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <cuda_runtime.h>
-
-namespace cg = cooperative_groups;
+#include <vector>
 
 #define CUDA_CHECK(call)                                                                    \
     do {                                                                                    \
@@ -31,24 +35,16 @@ static constexpr int BLOCK_SIZE = 256;
 static constexpr int MAX_BLOCKS = 64;
 static constexpr int TEST_ITERATIONS = 100;
 
-// Warp-level reduction via shuffle
-__device__ __forceinline__ int warpReduceSum(int val)
-{
-    for (int offset = warpSize / 2; offset > 0; offset /= 2)
-        val += __shfl_down_sync(0xffffffff, val, offset);
-    return val;
-}
-
-// Shared-memory reduction with warp shuffle for the final warp.
-// Each thread loads multiple elements (Brent's theorem) to keep the grid small.
+// Reduction kernel using cub::BlockReduce.
+// Each thread loads multiple elements via grid-stride loop (Brent's theorem)
+// to keep the grid small, then CUB handles the block-wide reduction.
 template <int BlockSize>
 __global__ void reduce_kernel(const int *__restrict__ g_idata, int *__restrict__ g_odata,
                               unsigned int n)
 {
-    extern __shared__ int sdata[];
-    cg::thread_block cta = cg::this_thread_block();
+    using BlockReduceT = cub::BlockReduce<int, BlockSize>;
+    __shared__ typename BlockReduceT::TempStorage temp_storage;
 
-    unsigned int tid = threadIdx.x;
     unsigned int i = blockIdx.x * BlockSize * 2 + threadIdx.x;
     unsigned int gridSize = BlockSize * 2 * gridDim.x;
 
@@ -60,31 +56,15 @@ __global__ void reduce_kernel(const int *__restrict__ g_idata, int *__restrict__
             mySum += g_idata[i + BlockSize];
         i += gridSize;
     }
-    sdata[tid] = mySum;
-    cg::sync(cta);
 
-    // Tree reduction in shared memory (compile-time unrolled)
-    if (BlockSize >= 512 && tid < 256) sdata[tid] = mySum = mySum + sdata[tid + 256];
-    cg::sync(cta);
-    if (BlockSize >= 256 && tid < 128) sdata[tid] = mySum = mySum + sdata[tid + 128];
-    cg::sync(cta);
-    if (BlockSize >= 128 && tid < 64) sdata[tid] = mySum = mySum + sdata[tid + 64];
-    cg::sync(cta);
+    // Block-wide reduction via CUB
+    int blockSum = BlockReduceT(temp_storage).Sum(mySum);
 
-    // Final warp: shuffle reduction
-    cg::thread_block_tile<32> tile32 = cg::tiled_partition<32>(cta);
-    if (cta.thread_rank() < 32) {
-        if (BlockSize >= 64)
-            mySum += sdata[tid + 32];
-        for (int offset = tile32.size() / 2; offset > 0; offset /= 2)
-            mySum += tile32.shfl_down(mySum, offset);
-    }
-
-    if (cta.thread_rank() == 0)
-        g_odata[blockIdx.x] = mySum;
+    if (threadIdx.x == 0)
+        g_odata[blockIdx.x] = blockSum;
 }
 
-// CPU reference using Kahan summation
+// CPU reference using simple summation
 static long long reduceCPU(const int *data, int n)
 {
     long long sum = 0;
@@ -106,8 +86,8 @@ int main(int argc, char **argv)
 {
     int n = parseIntArg(argc, argv, "-n", 1 << 26);  // 67108864
 
-    // Allocate and initialize host data
-    int *h_idata = new int[n];
+    // Initialize host data
+    std::vector<int> h_idata(n);
     for (int i = 0; i < n; i++)
         h_idata[i] = rand() & 0xFF;
 
@@ -115,16 +95,15 @@ int main(int argc, char **argv)
     int numBlocks = (n + (BLOCK_SIZE * 2 - 1)) / (BLOCK_SIZE * 2);
     if (numBlocks > MAX_BLOCKS) numBlocks = MAX_BLOCKS;
 
-    // Allocate device memory
-    int *d_idata, *d_odata;
-    CUDA_CHECK(cudaMalloc(&d_idata, (size_t)n * sizeof(int)));
-    CUDA_CHECK(cudaMalloc(&d_odata, numBlocks * sizeof(int)));
-    CUDA_CHECK(cudaMemcpy(d_idata, h_idata, (size_t)n * sizeof(int), cudaMemcpyHostToDevice));
+    // RAII device memory via thrust
+    thrust::device_vector<int> d_idata(h_idata.begin(), h_idata.end());
+    thrust::device_vector<int> d_odata(numBlocks);
 
-    int smem = BLOCK_SIZE * sizeof(int);
+    int *d_idata_ptr = thrust::raw_pointer_cast(d_idata.data());
+    int *d_odata_ptr = thrust::raw_pointer_cast(d_odata.data());
 
     // Warm-up
-    reduce_kernel<BLOCK_SIZE><<<numBlocks, BLOCK_SIZE, smem>>>(d_idata, d_odata, n);
+    reduce_kernel<BLOCK_SIZE><<<numBlocks, BLOCK_SIZE, 0>>>(d_idata_ptr, d_odata_ptr, n);
     CUDA_CHECK(cudaDeviceSynchronize());
 
     // Timed iterations using CUDA events
@@ -134,7 +113,7 @@ int main(int argc, char **argv)
 
     CUDA_CHECK(cudaEventRecord(start));
     for (int i = 0; i < TEST_ITERATIONS; i++)
-        reduce_kernel<BLOCK_SIZE><<<numBlocks, BLOCK_SIZE, smem>>>(d_idata, d_odata, n);
+        reduce_kernel<BLOCK_SIZE><<<numBlocks, BLOCK_SIZE, 0>>>(d_idata_ptr, d_odata_ptr, n);
     CUDA_CHECK(cudaEventRecord(stop));
     CUDA_CHECK(cudaEventSynchronize(stop));
 
@@ -143,14 +122,15 @@ int main(int argc, char **argv)
     double avgTimeSec = (totalMs / TEST_ITERATIONS) / 1000.0;
 
     // Read back block partial sums and finalize on CPU
-    int *h_odata = new int[numBlocks];
-    CUDA_CHECK(cudaMemcpy(h_odata, d_odata, numBlocks * sizeof(int), cudaMemcpyDeviceToHost));
+    std::vector<int> h_odata(numBlocks);
+    CUDA_CHECK(cudaMemcpy(h_odata.data(), d_odata_ptr, numBlocks * sizeof(int),
+                          cudaMemcpyDeviceToHost));
     long long gpuResult = 0;
     for (int i = 0; i < numBlocks; i++)
         gpuResult += h_odata[i];
 
     // CPU reference
-    long long cpuResult = reduceCPU(h_idata, n);
+    long long cpuResult = reduceCPU(h_idata.data(), n);
 
     // Report
     double throughput = 1.0e-9 * ((double)n * sizeof(int)) / avgTimeSec;
@@ -160,13 +140,9 @@ int main(int argc, char **argv)
     printf("CPU result = %lld\n", cpuResult);
     printf(gpuResult == cpuResult ? "Test passed\n" : "Test failed!\n");
 
-    // Cleanup
+    // Cleanup (events only — thrust handles device memory)
     CUDA_CHECK(cudaEventDestroy(start));
     CUDA_CHECK(cudaEventDestroy(stop));
-    CUDA_CHECK(cudaFree(d_idata));
-    CUDA_CHECK(cudaFree(d_odata));
-    delete[] h_idata;
-    delete[] h_odata;
 
     return (gpuResult == cpuResult) ? 0 : 1;
 }


### PR DESCRIPTION
## Description

New example in examples/compilers/nvbench_example/ showcasing NvBench for statistically rigorous kernel benchmarking with CompileIQ:

- Uses cub::BlockReduce and thrust::device_vector (NVIDIA library best practices)

- PTXAS search space applied to .cu source via -Xptxas --apply-controls

- NvBench entropy-based convergence with P75 latency metric

- CCCL include path auto-discovery for portable builds

Also updates nvcc_example/reduction.cu to use cub::BlockReduce and thrust::device_vector for consistency across examples.

Adds docs/benchmarking.md covering NvBench, Triton do_bench, manual CUDA Events, and NVIDIA Nsight Compute (profiling vs benchmarking).
