### PR TITLE
Fix Makefile target list and CI typecheck command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           cache-dependency-path: 'poetry.lock'
       - run: pip install poetry
       - run: poetry install --with typecheck,tracking,unittest
-      - run: poetry run pyright
+      - run: make typecheck
 
   unit-test:
     # Matrix matches `pyproject.toml`'s `python = ">=3.11,<3.14"` and the

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 
 .PHONY: help install install-examples install-docs lint lint-fix format format-check \
         typecheck test test-all test-unit test-integration test-fuzz test-cov \
-        docs docs-serve docs-preview build clean validate
-        docs docs-serve build clean validate check-internal \
+        docs docs-serve docs-preview build clean validate check-internal \
         build-search-space-manifest build-search-space-release-notes \
         build-search-space-release build-search-space-manifest-schema \
         check-search-space-manifest-schema clean-search-cache


### PR DESCRIPTION
Minor fix to Makefile, add a Makefile command to CI to catch Makefile format errors immediately.