### PR TITLE
Relax wheel smoke result count assertion

### DIFF
--- a/.github/scripts/smoke_test_compileiq_wheel.py
+++ b/.github/scripts/smoke_test_compileiq_wheel.py
@@ -45,7 +45,7 @@ def main():
     df = result.get_results()
     best = result.get_best_result()
 
-    assert len(df) >= 8
+    assert len(df) > 0
     assert "score_1" in df.columns
     assert "params" in df.columns
     assert isinstance(best, dict)


### PR DESCRIPTION
This is essentially a simpler version of the fix for the single_objective test in 8167ba84e19a180d2806b49ab88284f34538a9ae---simpler because this test is only to check definitions can be imported and used from the wheel.
