### PR TITLE
doc: add more CompileIQ links to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ test-cov-html: ## Run tests with coverage report
 	poetry run pytest tests/unit tests/integration -vvv --cov=compileiq --cov-report=html
 
 DOC_VERSION ?= latest
+DOCS_PORT ?= 8000
 
 docs: ## Build documentation for DOC_VERSION=latest or MAJOR.MINOR
 	@version="$(DOC_VERSION)"; \
@@ -80,8 +81,9 @@ docs-serve: ## Build and serve local docs preview
 	bash dev/view_docs.sh
 
 docs-preview: ## Build and serve live worktree docs locally
-	CIQ_DOCS_LOCAL_PREVIEW=1 CIQ_DOCS_BASE_URL=http://localhost:8000 DOC_VERSION=latest poetry run sphinx-build -E -a docs public/latest
-	python3 -m http.server 8000 --directory public
+	CIQ_DOCS_LOCAL_PREVIEW=1 CIQ_DOCS_BASE_URL=http://localhost:$(DOCS_PORT) DOC_VERSION=latest poetry run sphinx-build -E -a docs public/latest
+	@echo "Serving docs at http://localhost:$(DOCS_PORT)/latest/"
+	poetry run python -m http.server $(DOCS_PORT) --directory public
 
 build: ## Build wheel and sdist
 	poetry build

--- a/README.md
+++ b/README.md
@@ -2,15 +2,21 @@
 
 CompileIQ is a hyperparameter optimizer for tuning NVIDIA compiler controls and application parameters.
 
+[Documentation](https://nvidia.github.io/CompileIQ/stable/) |
+[PyPI](https://pypi.org/project/compileiq/) |
+[Latest Release](https://github.com/NVIDIA/CompileIQ/releases/latest) |
+[Search Space Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Search+Space+Catalog+Release&expanded=true) |
+[Booster Pack Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Booster+Pack+Catalog+Release&expanded=true)
+
 ## Quick install
 
-You can either install through PyPI:
+You can either install through [PyPI](https://pypi.org/project/compileiq/):
 
 ```bash
 pip install compileiq
 ```
 
-Or, build from the [repo](https://github.com/NVIDIA/CompileIQ) yourself:
+Or, build from the the source in this repository yourself:
 
 ```bash
 pip install -e .
@@ -34,6 +40,8 @@ search_space = PtxasSearchSpace(version="13.3", tag="search-spaces-2026.05.05")
 
 Set `CIQ_SEARCH_SPACES_DIR` to use a local mirror containing `manifest.json` plus the referenced `.bin` files. Set `CIQ_SEARCH_SPACES_REPO` to test or use a different release repository.
 
+Browse the published [Search Space Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Search+Space+Catalog+Release&expanded=true) to inspect available catalog assets and release notes.
+
 ## Environment Configuration Options
 
 | Environment Variable | Default Value | Type | Description
@@ -47,6 +55,8 @@ Set `CIQ_SEARCH_SPACES_DIR` to use a local mirror containing `manifest.json` plu
 ## Examples
 
 The `examples/` folder has simple examples for you to get started on using CompileIQ.
+
+For the full user guide, see the [CompileIQ documentation](https://nvidia.github.io/CompileIQ/stable/).
 
 If you are planning on running examples, you may need additional dependencies:
 


### PR DESCRIPTION
The README had very few links previously. This PR adds a few to assist with navigation for users.

Also, the `docs-preview` Make target can have the port used for the local docs server customized via the `DOCS_PORT` env var.