### PR TITLE
ci: always run required CI workflow for PR copies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,6 @@ on:
       # GitHub tag globs are not regexes. This catches CompileIQ package
       # release-looking tags such as v1.0.0, v1.0.0rc5, and v1.0.0dev1.
       - "v[0-9]*.[0-9]*.[0-9]*"
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".gitignore"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Remove the workflow-level path ignore from the required CI workflow so docs-only PR copies still report the CI Pass check.

This change is to fix the issue where the repository ruleset requires CI Pass before merge, but when all changed paths matched the current paths-ignore (e.g., only markdown updates), GitHub skips the workflow and the PR becomes essentially unmergable. This PR should address that. See https://github.com/NVIDIA/CompileIQ/pull/34 and https://github.com/NVIDIA/CompileIQ/pull/35.