### PR TITLE
Fix Triton example in Blackwell

### DIFF
--- a/agent-skills/compileiq-author-objective/SKILL.md
+++ b/agent-skills/compileiq-author-objective/SKILL.md
@@ -47,9 +47,10 @@ For paste-ready full-file templates per framework, see
 | Single provider, e.g. `PtxasSearchSpace()` | `def objective(config: str) -> float` | A hex string. Pass it straight to `save_compiler_config(acf_path, config)`. |
 | List, e.g. `[{"k": ss.choice(...)}, PtxasSearchSpace()]` | `def objective(mixed: list) -> float` | A list of the same length. Unpack: `user_space, ptxas_config = mixed`. |
 
-Mixed-space results have separate keys: `best["user_space"]` for the user-side
-knobs and `best["params"]` for the ACF hex string. (Pattern reference:
-`examples/compilers/triton_example/mixed_triton.py:97-118`.)
+Mixed-space results keep the same list shape in `best["params"]`. Unpack it
+before saving the ACF, for example:
+`user_space, ptxas_config = best["params"]`. (Pattern reference:
+`examples/compilers/triton_example/mixed_triton.py:123-146`.)
 
 For multi-objective, return `tuple[float, ...]` of length `num_objectives`.
 
@@ -97,7 +98,7 @@ absent — `flashinfer_cubin` and `flashinfer_jit_cache`. See
 |---|---|
 | Raw PTXAS (you have a `.ptx` file) | `ptxas --apply-controls candidate.acf kernel.ptx -arch=sm_100 -o kernel.cubin` |
 | NVCC source (CUDA `.cu`) | `nvcc -Xptxas --apply-controls=candidate.acf -arch=sm_100 kernel.cu -o exe` (canonical; see `examples/compilers/nvbench_example/optimize_reduction.py:108`) |
-| Triton kernel | kernel kwarg: `kernel[grid](..., ptx_options=f"--apply-controls={acf_path}")` plus `TRITON_ALWAYS_COMPILE=1` and `os.environ["TRITON_PTXAS_PATH"] = shutil.which("ptxas")` (see `examples/compilers/triton_example/mixed_triton.py:91-103`). This **replaces** the older `PTXAS_OPTIONS=` env-var approach for Triton. |
+| Triton kernel | kernel kwarg: `kernel[grid](..., ptx_options=f"--apply-controls={acf_path}")` plus `TRITON_ALWAYS_COMPILE=1`, `os.environ["TRITON_PTXAS_PATH"] = shutil.which("ptxas")`, and `os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = shutil.which("ptxas")` when Blackwell-specific PTXAS selection may apply. This **replaces** the older `PTXAS_OPTIONS=` env-var approach for Triton. |
 | Helion | Helion's official ACF API. See `https://helionlang.com/examples/acfs/softmax_acf.html`. Always set `HELION_SKIP_CACHE=1`. |
 | cuTeDSL / FA4 (TVM-FFI) | `cute.compile(..., options=f"{existing_options} --ptxas-options '--apply-controls {acf_path}'")`. If you can't reach the call site, patch `CompileCallable.__call__` to splice in the option string. |
 | FlashInfer | `FLASHINFER_EXTRA_CUDAFLAGS="--ptxas-options=--apply-controls=$ACF_FILE"` (see `docs/flashinfer_booster.md:107`). |
@@ -124,7 +125,7 @@ if not torch.allclose(actual, reference, atol=1e-2, rtol=0):
 return triton.testing.do_bench(lambda: kernel(...), warmup=100, rep=1000, return_mode="mean")
 ```
 
-(Pattern from `examples/compilers/triton_example/mixed_triton.py:113-118`.)
+(Pattern from `examples/compilers/triton_example/mixed_triton.py:141-146`.)
 
 ## Catch everything → return INVALID_SCORE
 
@@ -193,7 +194,8 @@ and `results.get_best_result()` returns a dict, your scaffold is correct.
   `ptx_options=` kernel kwarg. See the table above.
 - **Mixed search spaces require list unpacking.** If you pass
   `search_space=[user_dict, PtxasSearchSpace()]`, your objective must accept
-  a list, not a string. The result dict has separate `user_space` and `params`.
+  a list, not a string. Results keep that list in `best["params"]`; unpack it
+  before saving the compiler config.
 - **Don't redefine `INVALID_SCORE`.** Import it from `compileiq.types`. If
   you redefine it locally as `float('inf')`, the value happens to work today
   but is not guaranteed to in future releases.

--- a/agent-skills/compileiq-author-objective/references/templates.md
+++ b/agent-skills/compileiq-author-objective/references/templates.md
@@ -90,13 +90,14 @@ import torch, triton, triton.language as tl
 import compileiq.search_spaces.base as ss
 from compileiq.ciq import Search
 from compileiq.search_spaces.compilers import PtxasSearchSpace
-from compileiq.types import INVALID_SCORE, SearchConfiguration
+from compileiq.types import INVALID_SCORE, SearchConfiguration, WorkerTypes
+from compileiq.utils.gpu import gpu_benchmark_mode
 from compileiq.utils.helpers import save_compiler_config
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 USER_CONFIGS = [
-    {"block_m": 128, "block_n": 256, "block_k": 64, "stages": 3, "warps": 8},
-    {"block_m": 64,  "block_n": 256, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 32, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
     # ... add the configs your kernel supports
 ]
 
@@ -109,10 +110,20 @@ def my_kernel(...):  # your Triton kernel
 def run(a, b, acf_path, cfg):
     M, K = a.shape
     _, N = b.shape
+    assert M % cfg["block_m"] == 0
+    assert N % cfg["block_n"] == 0
+    assert K % cfg["block_k"] == 0
     c = torch.empty((M, N), device=a.device, dtype=torch.float16)
-    grid = (triton.cdiv(M, cfg["block_m"]) * triton.cdiv(N, cfg["block_n"]),)
-    my_kernel[grid](a, b, c, M, N, K, ..., num_stages=cfg["stages"], num_warps=cfg["warps"],
-                    ptx_options=f"--apply-controls={acf_path}")
+    grid = ((M // cfg["block_m"]) * (N // cfg["block_n"]),)
+    my_kernel[grid](
+        a, b, c, M, N, K, ...,
+        BLOCK_M=cfg["block_m"],
+        BLOCK_N=cfg["block_n"],
+        BLOCK_K=cfg["block_k"],
+        num_stages=cfg["stages"],
+        num_warps=cfg["warps"],
+        ptx_options=f"--apply-controls={acf_path}",
+    )
     return c
 
 
@@ -120,7 +131,9 @@ def objective(mixed_config: list) -> float:
     user_space, ptxas_config = mixed_config
     cfg = USER_CONFIGS[user_space["config_idx"]]
 
-    os.environ["TRITON_PTXAS_PATH"]    = shutil.which("ptxas")
+    ptxas_path = shutil.which("ptxas")
+    os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+    os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
     a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16)
@@ -151,9 +164,12 @@ if __name__ == "__main__":
         search_config=SearchConfiguration(problem_type="min", generations=10, pool_size=32),
         dump_results="results.csv",
     )
-    results = tuner.start()
+    with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
+        results = tuner.start(task_timeout=20)
     best = results.get_best_result()
-    save_compiler_config("best.acf", best["params"])
+    user_space, ptxas_config = best["params"]
+    print(f"best config index: {user_space['config_idx']}")
+    save_compiler_config("best.acf", ptxas_config)
 ```
 
 ---

--- a/agent-skills/compileiq-run-search/SKILL.md
+++ b/agent-skills/compileiq-run-search/SKILL.md
@@ -39,10 +39,11 @@ the worker, size the configuration, and run the search safely.
 
 ## Worker selection
 
-Pass the **Worker class itself** to `Search(worker_type=...)`, not the enum
-(`docs/workers.md:12`):
+Pass either a built-in `WorkerTypes` enum value or the worker class itself to
+`Search(worker_type=...)`:
 
 ```python
+from compileiq.types import WorkerTypes
 from compileiq.worker import (
     MultiProcessWorker,    # default
     IsoMultiProcessWorker, # spawns fresh process per task; kill-safe
@@ -54,6 +55,7 @@ from compileiq.worker import (
 | Situation | Worker class | Why |
 |---|---|---|
 | GPU kernel that may hang, OOM, or leak CUDA context | **`IsoMultiProcessWorker`** | One fresh process per task; parent kills on `task_timeout`. Defaults to `fork`. (`docs/workers.md:42`) |
+| Triton mixed example on Blackwell-class GPUs | `WorkerTypes.ISOLATED` + `CIQ_PROCESS_MODE=spawn` | Isolates each evaluation and avoids leaking illegal memory access state across runs. |
 | Fast (<100ms), stateless objective | `MultiProcessWorker` (default) | Reuses a pool; lower overhead. Defaults to `forkserver`. |
 | Multi-node / multi-GPU cluster | `RayWorker` | User must set up Ray cluster + install compileiq on every worker. Both `num_workers` and `task_timeout` are ignored. (`docs/workers.md:79-91`) |
 | I/O-bound `async def` objective | `AsyncWorker` | Concurrency, not parallelism. Rare for GPU work. |
@@ -106,7 +108,7 @@ tuner = Search(
     objective_function=objective,
     search_space=PtxasSearchSpace(version="13.3", variant="att"),
     search_config=config,
-    worker_type=IsoMultiProcessWorker,                 # class, not enum
+    worker_type=IsoMultiProcessWorker,                 # or WorkerTypes.ISOLATED
     tracker_config=LoguruTrackerConfig(sink="optimization.log"),
     dump_results=Path("results.csv"),                  # ALWAYS set this
     cache_folder=None,                                  # default ~/.cache/compileiq

--- a/docs/triton_example.md
+++ b/docs/triton_example.md
@@ -1,34 +1,57 @@
 # Tuning PTXAS for your Triton kernel
 
-In this section, we will build on an existing Triton tutorial kernel and apply PTXAS ACFs.
+This section shows how to apply CompileIQ-generated PTXAS ACFs to a Triton
+kernel. The basic example uses a fixed-config illustrative matmul kernel and
+searches only PTXAS controls. The companion mixed example shows how to search
+Triton launch/configuration knobs and PTXAS controls together.
 
 > The example code and supporting files can be found [in our repo here](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/triton_example/triton_ptx.py).
 
-## Matmul Triton Tutorial
+> Examples may become stale as triton or the compiler improve, and these examples are simple in nature, meant to teach you how to incorporate CompileIQ into your existing code
 
-The original kernel for the Triton tutorial can be found in [the Triton repository](https://github.com/triton-lang/triton/blob/v3.6.0/python/tutorials/03-matrix-multiplication.py).
+## Fixed-config matmul example
 
-Our goal is to apply CompileIQ on top of an existing matmul kernel to optimize runtime. Our changes are minimal: we do not modify the kernel code itself. Let’s walk through the integration before looking at the full objective function.
-
-### Specific Changes to Triton
-
-First, Triton is JIT-compiled, so we need to force recompilation for each ACF we try. An easy way to do this is by setting the environment variable `TRITON_ALWAYS_COMPILE`.
-
-Second, at the time of writing, Triton ships with its own PTXAS binary for ease of use. However, we need PTXAS 13.3 or higher to use CompileIQ’s ACF support. Therefore, we also override Triton’s default PTXAS with a local version via `TRITON_PTXAS_PATH`.
-
-You can do this programmatically with:
+The basic `triton_ptx.py` example keeps the Triton kernel configuration fixed:
 
 ```python
-import os
-os.environ["TRITON_ALWAYS_COMPILE"] = "1"
-os.environ["TRITON_PTXAS_PATH"] = "path/to/bin/ptxas"
+BLOCK_M = 32
+BLOCK_N = 64
+BLOCK_K = 32
+NUM_WARPS = 4
+NUM_STAGES = 3
 ```
 
-> For blackwell overwrites use: `TRITON_PTXAS_BLACKWELL_PATH` instead of `TRITON_PTXAS_PATH`
+It then tunes only the PTXAS compiler controls for that kernel and matrix
+shape. The example uses exact-tile `4096 x 4096` inputs, so `M`, `N`, and `K`
+must be divisible by the block sizes.
 
-Finally, we need to pass the ACF file to Triton so it can forward it to PTXAS. Triton already supports this via `ptx_options` when launching your kernel:
+## Specific changes for Triton
+
+Triton is JIT-compiled, so force recompilation for each ACF:
 
 ```python
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+```
+
+Triton ships its own PTXAS binary. CompileIQ ACF support requires
+PTXAS 13.3 or newer, so point Triton at the expected local `ptxas`. Set both
+environment variables when targeting systems where Triton may select a
+Blackwell-specific PTXAS path:
+
+```python
+ptxas_path = shutil.which("ptxas")
+if ptxas_path is None:
+    raise RuntimeError("ptxas not found in PATH.")
+
+os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
+```
+
+Pass the ACF to Triton through the `ptx_options` kernel-launch keyword:
+
+```python
+ptxas_options = f"--apply-controls={controls_path}" if controls_path else None
+
 matmul_kernel[grid](
     a,
     b,
@@ -42,170 +65,160 @@ matmul_kernel[grid](
     b.stride(1),
     c.stride(0),
     c.stride(1),
-    ACTIVATION=activation,
-    ptx_options=f"--apply-controls={ptx_acf_filename}",
+    BLOCK_M=BLOCK_M,
+    BLOCK_N=BLOCK_N,
+    BLOCK_K=BLOCK_K,
+    num_warps=NUM_WARPS,
+    num_stages=NUM_STAGES,
+    ptx_options=ptxas_options,
 )
 ```
 
-> You can optionally use the `PTX_OPTIONS` environment variable to pass in the `--apply-controls` flag instead of explicitly adding it to your kernel calls.
+> You can optionally use the `PTX_OPTIONS` environment variable to pass in the `--apply-controls` flag instead of explicitly adding it to your kernel calls. Note that this will be applied globally
 
 ### Building the objective function
 
-With everything in place, we can now build our objective function:
+The objective writes each sampled CompileIQ config to a temporary `.acf` file,
+passes that file to the Triton launch, checks correctness against Torch, and
+only then benchmarks runtime:
 
 ```python
-def objective(ptx_acf: str) -> float:
-    """
-    Our objective will minimize runtime. It applies the given
-    ACF to the kernel, verifies output correctness, and
-    benchmarks the runtime.
-    """
-
-    ptxas_path = shutil.which("ptxas")  # Ensures Triton picks up the expected ptxas
+def objective(config) -> float:
+    ptxas_path = shutil.which("ptxas")
     if ptxas_path is None:
         raise RuntimeError("ptxas not found in PATH.")
 
     os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+    os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
-    a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
-    b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
+    a = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
+    b = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
 
-    with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as tmp_acf_file:
-        save_compiler_config(tmp_acf_file.name, ptx_acf)
+    with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
+        save_compiler_config(f.name, config)
+        triton_out = matmul(a, b, f.name)
+        torch_out = torch.matmul(a, b)
 
-        triton_output = matmul(a, b, tmp_acf_file.name)
-        torch_output = torch.matmul(a, b)
+        if not torch.allclose(triton_out, torch_out, atol=1e-2, rtol=0):
+            return INVALID_SCORE
 
-        # Validating output
-        if not torch.allclose(triton_output, torch_output, atol=1e-2, rtol=0):
-            runtime = INVALID_SCORE
-        else:
-            # Benchmarking Advanced Controls File
-            runtime = triton.testing.do_bench(
-                lambda: matmul(a, b, tmp_acf_file.name),
-                warmup=100,
-                rep=1000,
-                return_mode="mean",
-            )
-
-    return runtime
+        return triton.testing.do_bench(
+            lambda: matmul(a, b, f.name),
+            warmup=100,
+            rep=1000,
+            return_mode="mean",
+        )
 ```
 
-Here’s what the function does:
+This objective follows the guardrails in the [Safety Section](compilers_overview.md#safety--correctness-read-this-first):
 
-* Sets environment variables for Triton to avoid caching and to use the expected PTXAS.
-* Creates a temporary file containing the sampled ACF from CompileIQ.
-* Passes that file into the `matmul` function from the [original tutorial](https://github.com/triton-lang/triton/blob/v3.6.0/python/tutorials/03-matrix-multiplication.py). This function is modified to pass the PTXAS CLI option `--apply-controls`, as described above.
-* Validating result correctness against Torch's implementation.
-* Performing benchmarking to get the runtime, only if the correctness test passed.
+* Force recompilation so each ACF can affect generated code.
+* Use an explicit PTXAS 13.3+ path.
+* Validate correctness before timing.
+* Return `INVALID_SCORE` for wrong answers.
 
-This objective is following all guidelines from our [Safety Section](compilers_overview.md#safety--correctness-read-this-first).
+### Expanding the search to different matrix sizes
 
-#### Expanding the search to different matrix sizes
+In the basic example, the search is specific to `4096 x 4096` matmul with the
+fixed block sizes above. If you want to support multiple sizes, you have a few
+options:
 
-In this example, we tune PTXAS controls for a specific matrix size of 512×512. If you want to support multiple sizes, you have a few options:
+* Run a separate search for each size.
+* Benchmark and validate all matrix sizes inside the objective and return an aggregate score.
+* Use a [multi-objective search](getting_started.md#multi-objective-searches) and return one score per size.
 
-* Perform one different search for each size
-* Benchmark and validate all matrix sizes inside the objective and return the mean, or only return a score if the ACF showed gains on most or all of the benchmarks
-* Perform a [multi-objective search](getting_started.md#multi-objective-searches) where you return one score for each of the sizes you want to support.
+### A note on performance
 
-#### A Note on Performance
-
-It is important that all measurements performed during the search are reliable. We provide helper functionality to lock clocks which will help with reproducibility and runtime stability.
+Reliable latency measurements are important during the search. CompileIQ
+provides a helper to lock clocks:
 
 ```python
 from compileiq.utils.gpu import gpu_benchmark_mode
 
 with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
-    results = tuner.start()
+    results = tuner.start(task_timeout=20)
 ```
 
-Because we are using the multiprocessing worker that only works locally, we can lock the clocks once before starting the search. If you are using Ray on multiple machines, you may want to either lock the clocks beforehand or use `gpu_benchmark_mode` inside the objective function to make sure the clocks are locked for each individual evaluation regardless of where it will execute.
+Because the default multiprocessing worker runs locally, you can lock clocks
+once before starting the search. If you use Ray across multiple machines, lock
+clocks before the run or use `gpu_benchmark_mode` inside the objective function
+so each remote evaluation runs under the same clock policy.
 
-## Expanding to Mixed-Search Spaces
+## Expanding to mixed search spaces
 
-Besides tuning PTXAS, CompileIQ often finds its best results when co-tuning other hyperparameters that matter to the application. In this example, Triton already does a good job with its own autotuner. As an example, we can disable the autotuner and expose those parameters to CompileIQ as part of the search space.
-
-First, remove the autotune decorator and keep the configs in an accessible location:
+Besides tuning PTXAS, CompileIQ can co-tune application parameters. The
+`mixed_triton.py` example searches a user-defined index into a list of Triton
+configs plus the PTXAS search space:
 
 ```python
 TRITON_CONFIGS = [
-    {
-        "block_size_m": 128,
-        "block_size_n": 256,
-        "block_size_k": 64,
-        "group_size_m": 8,
-        "num_stages": 3,
-        "num_warps": 8,
-    },
-    {
-        "block_size_m": 64,
-        "block_size_n": 256,
-        "block_size_k": 32,
-        "group_size_m": 8,
-        "num_stages": 4,
-        "num_warps": 4,
-    }, 
-    ... 
-    ]
+    {"block_m": 32, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 256, "block_k": 64, "stages": 3, "warps": 8},
+]
+
+search_space = [
+    {"config_idx": ss.range(0, len(TRITON_CONFIGS) - 1)},
+    PtxasSearchSpace(version=cuda_version),
+]
 ```
 
-We can now define a mixed search space containing the user space and PTX space.
+The objective receives a list with one entry per search-space component:
 
 ```python
-user_space = {"config_idx": ss.range(0, len(TRITON_CONFIGS) - 1)}
-ptx_space = PtxasSearchSpace(version=cuda_version)
-
-search_space_config = [user_space, ptx_space]
-
-tuner = Search(
-    objective_function=objective,
-    search_space=search_space_config,
-    search_config=main_config,
-)
-```
-
-Here we create a range parameter that indexes into `TRITON_CONFIGS`.
-
-In the objective function, we now receive a list with the user space and PTX space sampled separately. We adjust the objective to read the index and pass the selected config to the kernel:
-
-```python
-
-def objective(mixed_ss: list[dict, str]) -> float:
-
-    user_space, ptx_acf = mixed_ss
-    config_idx = user_space["config_idx"]
+def objective(mixed_config: list) -> float:
+    user_space, ptxas_config = mixed_config
+    cfg = TRITON_CONFIGS[user_space["config_idx"]]
 
     ...
 
-    triton_output = matmul(a, b, tmp_acf_file.name, **TRITON_CONFIGS[config_idx])
-
+    with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
+        save_compiler_config(f.name, ptxas_config)
+        triton_output = matmul(a, b, f.name, cfg)
 ```
 
-With this adjustment, CompileIQ can tune both PTX and user-space parameters together !
+Mixed-search results keep that same list shape in `best["params"]`. Unpack it
+before saving the ACF:
+
+```python
+best = results.get_best_result()
+user_space, ptxas_config = best["params"]
+
+print(f"Best Triton config index: {user_space['config_idx']}")
+save_compiler_config("best_matmul.acf", ptxas_config)
+```
+
+```python
+tuner = Search(
+    objective_function=objective,
+    search_space=search_space,
+    search_config=config,
+)
+```
 
 ### Expanding even further
 
-The example above is illustrative and reuses the pre-defined configurations for the Triton matmul example. Alternatively, you can search over block and group sizes independently.
-
-As an example, you could expose each option as a CompileIQ parameter:
+The example above indexes into a curated list of supported Triton configs.
+Alternatively, you can search over block and launch parameters directly:
 
 ```python
-
 user_space = {
-    "block_size_m": ss.range(16, 128, 16),
-    "block_size_n": ss.range(16, 256, 16),
-    "block_size_k": ss.range(16, 128, 16),
-    "group_size_m": ss.choice([4, 8, 16]),
-    "num_stages": ss.choice([2, 3, 4, 5]),
-    "num_warps": ss.choice([2, 4, 8]),
+    "block_m": ss.range(16, 128, 16),
+    "block_n": ss.range(16, 256, 16),
+    "block_k": ss.range(16, 128, 16),
+    "stages": ss.choice([2, 3, 4, 5]),
+    "warps": ss.choice([2, 4, 8]),
 }
 
-ptx_space = PtxasSearchSpace(version=cuda_version)
-
-search_space_config = [user_space, ptx_space]
-
+search_space = [
+    user_space,
+    PtxasSearchSpace(version=cuda_version),
+]
 ```
 
-Although this approach might require longer searches, it provides better visibility into how each combination behaves. You might even find good solutions where you least expect them.
+This approach may require longer searches, but it gives CompileIQ visibility
+into each parameter combination.
+

--- a/examples/compilers/triton_example/README.md
+++ b/examples/compilers/triton_example/README.md
@@ -6,7 +6,7 @@ Optimize Triton kernels with CompileIQ's PTXAS controls.
 
 ### Basic PTX Controls (`triton_ptx.py`)
 
-Optimizes a matmul kernel by tuning PTXAS compiler settings.
+Optimizes a fixed-config matmul kernel by tuning PTXAS compiler settings.
 
 ```bash
 python triton_ptx.py
@@ -31,7 +31,7 @@ python mixed_triton.py
 
 ## Output
 
-Both scripts generate `best_matmul.acf` - use with Triton's `ptx_options`:
+Both scripts generate `best_matmul.acf` - use with Triton's `ptx_options` or through `PTXAS_OPTIONS` env var:
 
 ```python
 kernel[grid](..., ptx_options="--apply-controls=best_matmul.acf")

--- a/examples/compilers/triton_example/mixed_triton.py
+++ b/examples/compilers/triton_example/mixed_triton.py
@@ -22,74 +22,100 @@ import triton.language as tl
 import compileiq.search_spaces.base as ss
 from compileiq.ciq import Search
 from compileiq.search_spaces.compilers import PtxasSearchSpace
-from compileiq.types import INVALID_SCORE, SearchConfiguration
+from compileiq.types import INVALID_SCORE, SearchConfiguration, WorkerTypes
+from compileiq.utils.gpu import gpu_benchmark_mode
 from compileiq.utils.helpers import save_compiler_config
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 # Triton configs to search over (user-defined space)
 TRITON_CONFIGS = [
-    {"block_m": 128, "block_n": 256, "block_k": 64, "group_m": 8, "stages": 3, "warps": 8},
-    {"block_m": 64, "block_n": 256, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
-    {"block_m": 128, "block_n": 128, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
-    {"block_m": 128, "block_n": 64, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
-    {"block_m": 64, "block_n": 128, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
+    {"block_m": 32, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 256, "block_k": 64, "stages": 3, "warps": 8},
 ]
+
+
+def is_blackwell_gpu() -> bool:
+    """Return True for Blackwell-class CUDA devices."""
+    major, _ = torch.cuda.get_device_capability(DEVICE)
+    return major >= 10
 
 
 @triton.jit
 def matmul_kernel(
-    a_ptr, b_ptr, c_ptr,
-    M, N, K,
-    stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
-    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr, ACTIVATION: tl.constexpr,
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
 ):
-    """Standard tiled matmul: C = A @ B"""
+    """Simple exact-tile matmul: C = A @ B."""
     pid = tl.program_id(0)
-    num_pid_m, num_pid_n = tl.cdiv(M, BLOCK_M), tl.cdiv(N, BLOCK_N)
-    num_pid_in_group = GROUP_M * num_pid_n
-    group_id = pid // num_pid_in_group
-    first_pid_m = group_id * GROUP_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
-    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
-    pid_n = (pid % num_pid_in_group) // group_size_m
+    num_pid_n = N // BLOCK_N
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
 
-    offs_am = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
-    offs_bn = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_k = tl.arange(0, BLOCK_K)
-    a_ptrs = a_ptr + offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
-    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
-        acc = tl.dot(a, b, acc)
-        a_ptrs += BLOCK_K * stride_ak
-        b_ptrs += BLOCK_K * stride_bk
+    for k in range(0, K, BLOCK_K):
+        k_idxs = k + offs_k
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + k_idxs[None, :] * stride_ak
+        b_ptrs = b_ptr + k_idxs[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        acc += tl.dot(a, b)
 
     c = acc.to(tl.float16)
-    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    c_ptrs = c_ptr + offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn
-    tl.store(c_ptrs, c, mask=(offs_cm[:, None] < M) & (offs_cn[None, :] < N))
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, c)
 
 
-def matmul(a, b, acf_path: str, cfg: dict):
-    """Run matmul with custom Triton config and PTXAS controls."""
+def matmul(a, b, controls_path: str, cfg: dict):
+    """Run the exact-tile matmul with custom Triton config and PTXAS controls."""
     assert a.shape[1] == b.shape[0] and a.is_contiguous()
     M, K = a.shape
     _, N = b.shape
+    assert M % cfg["block_m"] == 0
+    assert N % cfg["block_n"] == 0
+    assert K % cfg["block_k"] == 0
     c = torch.empty((M, N), device=a.device, dtype=torch.float16)
-    grid = (triton.cdiv(M, cfg["block_m"]) * triton.cdiv(N, cfg["block_n"]),)
+    grid = ((M // cfg["block_m"]) * (N // cfg["block_n"]),)
+    ptxas_options = f"--apply-controls={controls_path}" if controls_path else None
     matmul_kernel[grid](
-        a, b, c, M, N, K,
-        a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
-        BLOCK_M=cfg["block_m"], BLOCK_N=cfg["block_n"], BLOCK_K=cfg["block_k"],
-        GROUP_M=cfg["group_m"], ACTIVATION="",
-        num_stages=cfg["stages"], num_warps=cfg["warps"],
-        ptx_options=f"--apply-controls={acf_path}",
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=cfg["block_m"],
+        BLOCK_N=cfg["block_n"],
+        BLOCK_K=cfg["block_k"],
+        num_stages=cfg["stages"],
+        num_warps=cfg["warps"],
+        ptx_options=ptxas_options,
     )
     return c
 
@@ -99,11 +125,13 @@ def objective(mixed_config: list) -> float:
     user_space, ptxas_config = mixed_config
     cfg = TRITON_CONFIGS[user_space["config_idx"]]
 
-    os.environ["TRITON_PTXAS_PATH"] = shutil.which("ptxas")
+    ptxas_path = shutil.which("ptxas")
+    os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+    os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
-    a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
-    b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
+    a = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
+    b = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
 
     with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
         save_compiler_config(f.name, ptxas_config)
@@ -134,18 +162,28 @@ def main():
 
     # Configure and run search
     config = SearchConfiguration(problem_type="min", generations=5, pool_size=32)
+    search_kwargs = {}
+    if is_blackwell_gpu():
+        # This specific example may cause Illegal Memory accesses
+        # We leverage fully isolated processes to prevent leaking across runs
+        os.environ["CIQ_PROCESS_MODE"] = "spawn"
+        search_kwargs["worker_type"] = WorkerTypes.ISOLATED
+
     tuner = Search(
         objective_function=objective,
         search_space=search_space,
         search_config=config,
+        **search_kwargs,
     )
-    results = tuner.start()
+    with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
+        results = tuner.start(task_timeout=20)
 
     # Save best result
     best = results.get_best_result()
+    user_space, ptxas_config = best["params"]
     print(f"Best runtime: {best['score_1']:.4f} ms")
-    print(f"Best Triton config index: {best['user_space']['config_idx']}")
-    save_compiler_config("best_matmul.acf", best["params"])
+    print(f"Best Triton config index: {user_space['config_idx']}")
+    save_compiler_config("best_matmul.acf", ptxas_config)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Modified the kernel to stop using the triton matmul example as it was giving too many illegal memory accesses on blackwell. The current example takes more time to run, but should work on Hopper and Blackwell without too many hiccups.

Documentation and skills are updated accordingly.