### PR TITLE
Fix core wrapper failing on install paths with spaces

### DIFF
--- a/compileiq/core/executable/core-manifest.json
+++ b/compileiq/core/executable/core-manifest.json
@@ -7,14 +7,14 @@
   "pipeline_id": 53625600,
   "files": {
     "linux/aarch64/bin/_core": "sha256:a3e32c027b397b8c7e68b6d39bdd01d1877e0ed11008dab6444334277100007c",
-    "linux/aarch64/bin/core": "sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882",
+    "linux/aarch64/bin/core": "sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8",
     "linux/aarch64/lib/libciq.so": "sha256:7e798e4540905db1942be5d8a740b08390922b900a601afe4d43adf054ec5b7e",
     "linux/x86_64/bin/_core": "sha256:0fea2a15f0935c2c0c511822d3772a27a4695b3b7912aa089051ef9dea527d4c",
-    "linux/x86_64/bin/core": "sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882",
+    "linux/x86_64/bin/core": "sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8",
     "linux/x86_64/lib/libciq.so": "sha256:e49d1b0fbe196d0ca3f3aafc16db53823136d98b353d1c001768d459e3f2f04c",
     "win32/amd64/core.exe": "sha256:9b4f1a63193d2cad5787ed515f57d20ff0b62e52d687e9bb989d7f26d7ce7c53",
     "win32/amd64/libciq.dll": "sha256:37df95add866f884590ec5c70bce117650799b55d82da571ce75334ae060b6e3"
   },
   "source_manifest_sha256": "sha256:f447906f7d62d36fc62d8c88480e5ae1d6edad07ed7044ac2db3f533196aa558",
-  "core_lock": "sha256:17f57b4235307a848d8b465f87773b97e20f5ca485c97084f94ccb8f573d1282"
+  "core_lock": "sha256:c3c0d0f445778ca437e2ef7231562eeb38e9e99a22d974eb87463aaa6ec5a722"
 }

--- a/compileiq/core/executable/linux/aarch64/bin/core
+++ b/compileiq/core/executable/linux/aarch64/bin/core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882
-size 224
+oid sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8
+size 165

--- a/compileiq/core/executable/linux/x86_64/bin/core
+++ b/compileiq/core/executable/linux/x86_64/bin/core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882
-size 224
+oid sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8
+size 165


### PR DESCRIPTION
## Description

The bundled core launcher `compileiq/core/executable/linux/{x86_64,aarch64}/bin/core` leaves its path variables unquoted:

```sh
LAUNCHER=$(readlink -f $0)
LAUNCHERPATH=$(dirname $LAUNCHER)
$LAUNCHERPATH/_core "$@"
```

When the resolved install path contains a space, `/bin/sh` word-splits these lines and tries to execute a directory instead of `_core`, so the core never
starts and a `Search` fails. This PR quotes `$0`, `$LAUNCHER`, and `$LAUNCHERPATH` in both Linux wrappers (same LFS blob) and regenerates the
`core-manifest.json` hashes + `core_lock` to match.

## Checklist

- [ X ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/CompileIQ/blob/main/CONTRIBUTING.md).
- [ N/A - not covered in test already or necessary] - New or existing tests cover these changes.
- [ N/A - not covered in docs already or necessary ] - The documentation is up to date with these changes.

## Validation

Ran end-to-end from a path containing a space (`examples/single_objective.py`, real core launch + socket IPC):

- `main` (before): core never starts, run fails with a socket `TimeoutError`
- this branch (after): search completes 5 generations, returns the correct best result, exit 0
- `python -m compileiq.core.verify_core` -> `OK`

## Bug fix

With this PR not applied, install (or run) CompileIQ from any path containing a space and start a search to reproduce error:

```python
# Run from e.g. "/home/user/My Projects/CompileIQ"
from compileiq.ciq import Search
from compileiq.types import SearchConfiguration
import compileiq.search_spaces.base as ss

tuner = Search(
    objective_function=lambda c: c["x"] ** 2 + c["y"],
    search_space={"x": ss.range(start=1.0, end=20.0, step=0.5), "y": ss.choice([1, 2, 3])},
    search_config=SearchConfiguration(generations=5, problem_type="min", num_objectives=1),
)
tuner.start()  # core fails to launch -> socket TimeoutError
```
