### PR TITLE
Ports bug fixes from main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,14 +5,13 @@
 
 ## Checklist
 
-- [ ] I am familiar with the [Contributing Guidelines](https://nvidia.github.io/CompileIQ/user_guide/contribution_guide.html).
+- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/CompileIQ/blob/main/CONTRIBUTING.md).
 - [ ] New or existing tests cover these changes.
 - [ ] The documentation is up to date with these changes.
 
-## Test plan
+## Validation
 
-<!-- How did you verify these changes? Example commands, test names,
-     or manual steps. -->
+<!-- How did you validate these changes? Test names, example commands, manual steps, etc. -->
 
 ## Bug fix
 
@@ -21,7 +20,7 @@
 
 ```python
 import compileiq as ciq
-# Code that demonstrates the bug
+# Code with a minimal example that demonstrates the bug
 ```
 
 ## New feature / enhancement

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,6 @@ on:
       # GitHub tag globs are not regexes. This catches CompileIQ package
       # release-looking tags such as v1.0.0, v1.0.0rc5, and v1.0.0dev1.
       - "v[0-9]*.[0-9]*.[0-9]*"
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".gitignore"
   workflow_dispatch:
 
 concurrency:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,204 @@
+# Contributing to CompileIQ
+
+CompileIQ is NVIDIA's hyperparameter optimizer for tuning compiler controls. This guide is for both external community contributors and NVIDIA team members. The expected flow is: open an issue, branch from `main`, code, add tests, sign off your commits per the [DCO](#signing-your-work), and open a pull request for review.
+
+For installation and end-user docs, see [`README.md`](README.md) and the [CompileIQ documentation](https://nvidia.github.io/CompileIQ/stable/). For internal architecture and module layout, see [`AGENTS.md`](AGENTS.md).
+
+## Signing your work
+
+Every commit must carry a `Signed-off-by:` trailer matching your git `user.name` and `user.email`. The simplest way is to use `-s` on every commit:
+
+```bash
+git commit -s -m "Add core manifest verification"
+```
+
+This requirement applies to commits made on or after this guide lands; existing history is not retroactively re-signed.
+
+If you forgot to sign off, fix it before pushing:
+
+```bash
+git commit --amend -s --no-edit                # last commit
+git rebase -i --signoff <upstream-base>        # older commits in your branch
+```
+
+By signing off, you certify the following Developer Certificate of Origin for every contribution you make:
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+## Reporting issues
+
+File issues from the templates in [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/):
+
+- [`1-bug-report.yml`](.github/ISSUE_TEMPLATE/1-bug-report.yml) — bugs and regressions.
+- [`2-feature-request.md`](.github/ISSUE_TEMPLATE/2-feature-request.md) — new functionality.
+- [`3-question.md`](.github/ISSUE_TEMPLATE/3-question.md) — usage questions.
+- [`4-documentation.md`](.github/ISSUE_TEMPLATE/4-documentation.md) — documentation gaps or errors.
+
+For bug reports, include the CompileIQ version (`pip show compileiq`), Python version, OS, and a minimal reproducer. The maintainers listed in [`.github/CODEOWNERS`](.github/CODEOWNERS) triage incoming issues.
+
+**Security:** Do *not* report security vulnerabilities through public GitHub issues or pull requests. Follow the disclosure process in [`SECURITY.md`](SECURITY.md) (web form or `psirt@nvidia.com`).
+
+## Types of contributions
+
+- **Bug fix or small change** — open a pull request directly; reference the issue with `closes #N` if one exists.
+- **New feature or non-trivial enhancement** — open an issue first to align on design before writing code.
+- **Documentation or [`agent-skills/`](agent-skills/) tweaks** — open a pull request directly; label the related issue (if any) as `documentation`.
+
+## Development setup
+
+Prerequisites: Python 3.11–3.13, [Poetry](https://python-poetry.org/), `git`, and either Linux or Windows (the supported CI hosts).
+
+External contributors fork [`NVIDIA/CompileIQ`](https://github.com/NVIDIA/CompileIQ) and add an upstream remote:
+
+```bash
+git clone https://github.com/<your-username>/CompileIQ.git
+cd CompileIQ
+git remote add upstream https://github.com/NVIDIA/CompileIQ.git
+```
+
+NVIDIA team members may clone `NVIDIA/CompileIQ` directly.
+
+Install dependencies:
+
+```bash
+make install           # dev dependencies (linter, typecheck, unittest, tracking)
+make install-examples  # add examples deps
+make install-docs      # add docs deps
+```
+
+Verify your environment:
+
+```bash
+make verify-core   # validate bundled core binaries against core-manifest.json
+make validate      # lint + typecheck + verify-core + unit tests
+```
+
+For deeper architecture and module-by-module orientation, see [`AGENTS.md`](AGENTS.md).
+
+## Branching workflow
+
+- **External contributors:** branch in your fork and open a pull request against `NVIDIA/CompileIQ:main`. Any branch name is fine in your fork.
+- **NVIDIA team members:** push a feature branch directly to `NVIDIA/CompileIQ` and open a pull request against `main`. Direct pushes to `main` are not allowed — everything lands through pull request review.
+- **Branch naming (internal):** use `<github-username>/<short-description>`, e.g. `asrikanth/add-contributing-md`. Keep it descriptive and lowercase-with-hyphens.
+- **Long-lived branches:**
+  - `main` — active development; all pull requests target this.
+  - `release-x.y` — release branches; hotfixes only.
+  - `gh-pages` — managed by the docs workflow; do not push directly.
+
+## Coding standards
+
+The project uses [Ruff](https://docs.astral.sh/ruff/) for linting and formatting and [Pyright](https://microsoft.github.io/pyright/) for type checking. Both are configured in [`pyproject.toml`](pyproject.toml) and [`pyrightconfig.json`](pyrightconfig.json).
+
+- Ruff: rules `E` and `F`, line length 100, indent 4 spaces, double quotes, target Python 3.11.
+- Pyright: standard mode against `compileiq/` and `tests/`. Looser checks under `tests/integration/` and `tests/fuzz/` are intentional.
+
+Run before pushing:
+
+```bash
+make lint           # ruff check
+make lint-fix       # ruff check --fix
+make format         # ruff format
+make format-check   # verify formatting without changes
+make typecheck      # pyright
+```
+
+Match the patterns of existing modules; the module map in [`AGENTS.md`](AGENTS.md) is the canonical reference.
+
+## Tests
+
+Every behavior-changing pull request must add or update tests.
+
+The test suite has three tiers (see [`tests/`](tests/) and [`AGENTS.md`](AGENTS.md)):
+
+- `tests/unit/` — fast, deterministic, no external deps.
+- `tests/integration/` — mocked-core Search tests with deterministic `@pytest.mark.parametrize`.
+- `tests/fuzz/` — [Hypothesis](https://hypothesis.readthedocs.io/)-based with wide parameter ranges. **Excluded from default `pytest` runs** via `addopts = "--ignore=tests/fuzz"` in [`pyproject.toml`](pyproject.toml). Run explicitly. Set `CIQ_FUZZ_EXAMPLES=100` for thorough sweeps (the nightly workflow does this).
+
+Markers (defined in `pyproject.toml`):
+
+- `requires_ray` — needs a running Ray cluster.
+- `requires_ipc` — needs real sockets or subprocesses.
+- `requires_core` — runs the real core binary (not sandbox-compatible).
+
+Commands:
+
+```bash
+make test-unit          # all unit tests
+make test-integration   # all integration tests
+make test-fuzz          # fuzz tests (slow)
+make test-cov           # unit + integration with terminal coverage
+make test-cov-html      # ... with HTML coverage report
+
+# Single test:
+poetry run pytest tests/unit/test_ciq.py::TestClassName::test_method -vvv
+```
+
+If your change affects user-facing behavior or public API, preview the docs locally with `make docs-preview` (then open <http://localhost:8000/latest/>) and update files under [`docs/`](docs/) as needed.
+
+## Commit messages
+
+- Imperative subject, ≤ 72 characters: *"Add core manifest verification"*, *"Fix flaky single-objective integration test"*.
+- An optional `type:` prefix is used loosely in this repo — `doc:`, `chore:`, `fix:`. Not validated, not required.
+- Use the commit body to explain *why* when the change is not obvious from the diff.
+- Reference issues with `closes #N` or `refs #N` in the body or the pull-request description.
+- **Every commit must be DCO-signed** — see [Signing your work](#signing-your-work). Use `git commit -s`.
+
+## Submitting a pull request
+
+1. Push your branch and open a pull request against `main`.
+2. Fill in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) end-to-end: description, checklist, test plan, and the bug-fix or new-feature code example where relevant.
+3. Keep pull requests focused — one concern per pull request. Split refactors from behavior changes when feasible.
+4. Update [`docs/`](docs/) for any public-API or user-facing change.
+
+CI must be green before review. Required and informative checks include `lint`, `typecheck`, `verify-core`, `unit-test` (Python 3.11/3.12/3.13 × Ubuntu/Windows), `integration-test`, `fuzz-test`, `run-examples`, `validate-binary-ss`, and the wheel smoke tests. See [`.github/workflows/ci.yml`](.github/workflows/ci.yml) for the full matrix.
+
+## Code review
+
+- At least one [CODEOWNERS](.github/CODEOWNERS) approval is required before merge.
+- Address review comments with additional commits — do not force-push during active review.
+- Pull requests idle for more than 30 days may be closed; reopen when you have time to continue.
+
+## License
+
+CompileIQ is distributed under the NVIDIA Software License Agreement; see [`LICENSE`](LICENSE), [`EULA`](EULA), and [`NOTICE`](NOTICE) for the full terms. Opening a pull request signifies acceptance of those terms in addition to the DCO sign-off above.
+
+---
+

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ test-cov-html: ## Run tests with coverage report
 	poetry run pytest tests/unit tests/integration -vvv --cov=compileiq --cov-report=html
 
 DOC_VERSION ?= latest
+DOCS_PORT ?= 8000
 
 docs: ## Build documentation for DOC_VERSION=latest or MAJOR.MINOR
 	@version="$(DOC_VERSION)"; \
@@ -80,8 +81,9 @@ docs-serve: ## Build and serve local docs preview
 	bash dev/view_docs.sh
 
 docs-preview: ## Build and serve live worktree docs locally
-	CIQ_DOCS_LOCAL_PREVIEW=1 CIQ_DOCS_BASE_URL=http://localhost:8000 DOC_VERSION=latest poetry run sphinx-build -E -a docs public/latest
-	python3 -m http.server 8000 --directory public
+	CIQ_DOCS_LOCAL_PREVIEW=1 CIQ_DOCS_BASE_URL=http://localhost:$(DOCS_PORT) DOC_VERSION=latest poetry run sphinx-build -E -a docs public/latest
+	@echo "Serving docs at http://localhost:$(DOCS_PORT)/latest/"
+	poetry run python -m http.server $(DOCS_PORT) --directory public
 
 build: ## Build wheel and sdist
 	poetry build

--- a/README.md
+++ b/README.md
@@ -2,15 +2,21 @@
 
 CompileIQ is a hyperparameter optimizer for tuning NVIDIA compiler controls and application parameters.
 
+[Documentation](https://nvidia.github.io/CompileIQ/stable/) |
+[PyPI](https://pypi.org/project/compileiq/) |
+[Latest Release](https://github.com/NVIDIA/CompileIQ/releases/latest) |
+[Search Space Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Search+Space+Catalog+Release&expanded=true) |
+[Booster Pack Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Booster+Pack+Catalog+Release&expanded=true)
+
 ## Quick install
 
-You can either install through PyPI:
+You can either install through [PyPI](https://pypi.org/project/compileiq/):
 
 ```bash
 pip install compileiq
 ```
 
-Or, build from the [repo](https://github.com/NVIDIA/CompileIQ) yourself:
+Or, build from the the source in this repository yourself:
 
 ```bash
 pip install -e .
@@ -43,6 +49,8 @@ search_space = PtxasSearchSpace(version="13.3", tag="search-spaces-2026.05.05")
 
 Set `CIQ_SEARCH_SPACES_DIR` to use a local mirror containing `manifest.json` plus the referenced `.bin` files. Set `CIQ_SEARCH_SPACES_REPO` to test or use a different release repository.
 
+Browse the published [Search Space Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Search+Space+Catalog+Release&expanded=true) to inspect available catalog assets and release notes.
+
 ## Environment Configuration Options
 
 | Environment Variable | Default Value | Type | Description
@@ -56,6 +64,8 @@ Set `CIQ_SEARCH_SPACES_DIR` to use a local mirror containing `manifest.json` plu
 ## Examples
 
 The `examples/` folder has simple examples for you to get started on using CompileIQ.
+
+For the full user guide, see the [CompileIQ documentation](https://nvidia.github.io/CompileIQ/stable/).
 
 If you are planning on running examples, you may need additional dependencies:
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
 # CompileIQ - NVIDIA Compiler HPO
 
-CompileIQ is a hyperparameter optimizer for tuning NVIDIA compiler controls and application parameters.
+**Push GPU kernels further with NVIDIA compiler tuning.**
 
-[Documentation](https://nvidia.github.io/CompileIQ/stable/) |
-[PyPI](https://pypi.org/project/compileiq/) |
-[Latest Release](https://github.com/NVIDIA/CompileIQ/releases/latest) |
-[Search Space Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Search+Space+Catalog+Release&expanded=true) |
-[Booster Pack Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Booster+Pack+Catalog+Release&expanded=true)
+CompileIQ is a hyperparameter optimizer for NVIDIA compiler controls and application parameters. It helps kernel developers tune those controls against workload-specific benchmarks, adding another optimization path for CUDA C++, Triton, and Helion kernels after source-level tuning has plateaued.
+
+[Documentation](https://nvidia.github.io/CompileIQ/stable/) | [PyPI](https://pypi.org/project/compileiq/) | [Latest Release](https://github.com/NVIDIA/CompileIQ/releases/latest) | [Search Space Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Search+Space+Catalog+Release&expanded=true) | [Booster Pack Catalog Releases](https://github.com/NVIDIA/CompileIQ/releases?q=Booster+Pack+Catalog+Release&expanded=true)
+
+## What CompileIQ Does
+
+CompileIQ tunes NVIDIA compilers to your workload using the compiler's [Advanced Controls](https://nvidia.github.io/CompileIQ/stable/compilers_overview.html) interface. At a high level CompileIQ:
+
+- Searches optimal PTXAS and NVCC Advanced Controls for your target kernel.
+- Iteratively measures candidates against metrics defined by you (runtime, compile time, power, etc).
+- Produces an Advanced Control File (ACF) that can be distributed with the kernel.
+- Supports CUDA C++, Triton, and Helion tuning workflows.
+
+## Basic Workflow
+
+1. Define the kernel benchmark and objective.
+2. Run CompileIQ over the relevant compiler controls.
+3. Apply the generated ACF in future builds or JIT compilation.
+
+Tune the compiler to the workload.
+
+See the [documentation](https://nvidia.github.io/CompileIQ/stable/) and [examples](#examples) for more.
 
 ## Quick install
 

--- a/agent-skills/compileiq-author-objective/SKILL.md
+++ b/agent-skills/compileiq-author-objective/SKILL.md
@@ -47,9 +47,10 @@ For paste-ready full-file templates per framework, see
 | Single provider, e.g. `PtxasSearchSpace()` | `def objective(config: str) -> float` | A hex string. Pass it straight to `save_compiler_config(acf_path, config)`. |
 | List, e.g. `[{"k": ss.choice(...)}, PtxasSearchSpace()]` | `def objective(mixed: list) -> float` | A list of the same length. Unpack: `user_space, ptxas_config = mixed`. |
 
-Mixed-space results have separate keys: `best["user_space"]` for the user-side
-knobs and `best["params"]` for the ACF hex string. (Pattern reference:
-`examples/compilers/triton_example/mixed_triton.py:97-118`.)
+Mixed-space results keep the same list shape in `best["params"]`. Unpack it
+before saving the ACF, for example:
+`user_space, ptxas_config = best["params"]`. (Pattern reference:
+`examples/compilers/triton_example/mixed_triton.py:123-146`.)
 
 For multi-objective, return `tuple[float, ...]` of length `num_objectives`.
 
@@ -97,7 +98,7 @@ absent — `flashinfer_cubin` and `flashinfer_jit_cache`. See
 |---|---|
 | Raw PTXAS (you have a `.ptx` file) | `ptxas --apply-controls candidate.acf kernel.ptx -arch=sm_100 -o kernel.cubin` |
 | NVCC source (CUDA `.cu`) | `nvcc -Xptxas --apply-controls=candidate.acf -arch=sm_100 kernel.cu -o exe` (canonical; see `examples/compilers/nvbench_example/optimize_reduction.py:108`) |
-| Triton kernel | kernel kwarg: `kernel[grid](..., ptx_options=f"--apply-controls={acf_path}")` plus `TRITON_ALWAYS_COMPILE=1` and `os.environ["TRITON_PTXAS_PATH"] = shutil.which("ptxas")` (see `examples/compilers/triton_example/mixed_triton.py:91-103`). This **replaces** the older `PTXAS_OPTIONS=` env-var approach for Triton. |
+| Triton kernel | kernel kwarg: `kernel[grid](..., ptx_options=f"--apply-controls={acf_path}")` plus `TRITON_ALWAYS_COMPILE=1`, `os.environ["TRITON_PTXAS_PATH"] = shutil.which("ptxas")`, and `os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = shutil.which("ptxas")` when Blackwell-specific PTXAS selection may apply. This **replaces** the older `PTXAS_OPTIONS=` env-var approach for Triton. |
 | Helion | Helion's official ACF API. See `https://helionlang.com/examples/acfs/softmax_acf.html`. Always set `HELION_SKIP_CACHE=1`. |
 | cuTeDSL / FA4 (TVM-FFI) | `cute.compile(..., options=f"{existing_options} --ptxas-options '--apply-controls {acf_path}'")`. If you can't reach the call site, patch `CompileCallable.__call__` to splice in the option string. |
 | FlashInfer | `FLASHINFER_EXTRA_CUDAFLAGS="--ptxas-options=--apply-controls=$ACF_FILE"` (see `docs/flashinfer_booster.md:107`). |
@@ -124,7 +125,7 @@ if not torch.allclose(actual, reference, atol=1e-2, rtol=0):
 return triton.testing.do_bench(lambda: kernel(...), warmup=100, rep=1000, return_mode="mean")
 ```
 
-(Pattern from `examples/compilers/triton_example/mixed_triton.py:113-118`.)
+(Pattern from `examples/compilers/triton_example/mixed_triton.py:141-146`.)
 
 ## Catch everything → return INVALID_SCORE
 
@@ -193,7 +194,8 @@ and `results.get_best_result()` returns a dict, your scaffold is correct.
   `ptx_options=` kernel kwarg. See the table above.
 - **Mixed search spaces require list unpacking.** If you pass
   `search_space=[user_dict, PtxasSearchSpace()]`, your objective must accept
-  a list, not a string. The result dict has separate `user_space` and `params`.
+  a list, not a string. Results keep that list in `best["params"]`; unpack it
+  before saving the compiler config.
 - **Don't redefine `INVALID_SCORE`.** Import it from `compileiq.types`. If
   you redefine it locally as `float('inf')`, the value happens to work today
   but is not guaranteed to in future releases.

--- a/agent-skills/compileiq-author-objective/references/templates.md
+++ b/agent-skills/compileiq-author-objective/references/templates.md
@@ -90,13 +90,14 @@ import torch, triton, triton.language as tl
 import compileiq.search_spaces.base as ss
 from compileiq.ciq import Search
 from compileiq.search_spaces.compilers import PtxasSearchSpace
-from compileiq.types import INVALID_SCORE, SearchConfiguration
+from compileiq.types import INVALID_SCORE, SearchConfiguration, WorkerTypes
+from compileiq.utils.gpu import gpu_benchmark_mode
 from compileiq.utils.helpers import save_compiler_config
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 USER_CONFIGS = [
-    {"block_m": 128, "block_n": 256, "block_k": 64, "stages": 3, "warps": 8},
-    {"block_m": 64,  "block_n": 256, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 32, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
     # ... add the configs your kernel supports
 ]
 
@@ -109,10 +110,20 @@ def my_kernel(...):  # your Triton kernel
 def run(a, b, acf_path, cfg):
     M, K = a.shape
     _, N = b.shape
+    assert M % cfg["block_m"] == 0
+    assert N % cfg["block_n"] == 0
+    assert K % cfg["block_k"] == 0
     c = torch.empty((M, N), device=a.device, dtype=torch.float16)
-    grid = (triton.cdiv(M, cfg["block_m"]) * triton.cdiv(N, cfg["block_n"]),)
-    my_kernel[grid](a, b, c, M, N, K, ..., num_stages=cfg["stages"], num_warps=cfg["warps"],
-                    ptx_options=f"--apply-controls={acf_path}")
+    grid = ((M // cfg["block_m"]) * (N // cfg["block_n"]),)
+    my_kernel[grid](
+        a, b, c, M, N, K, ...,
+        BLOCK_M=cfg["block_m"],
+        BLOCK_N=cfg["block_n"],
+        BLOCK_K=cfg["block_k"],
+        num_stages=cfg["stages"],
+        num_warps=cfg["warps"],
+        ptx_options=f"--apply-controls={acf_path}",
+    )
     return c
 
 
@@ -120,7 +131,9 @@ def objective(mixed_config: list) -> float:
     user_space, ptxas_config = mixed_config
     cfg = USER_CONFIGS[user_space["config_idx"]]
 
-    os.environ["TRITON_PTXAS_PATH"]    = shutil.which("ptxas")
+    ptxas_path = shutil.which("ptxas")
+    os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+    os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
     a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16)
@@ -151,9 +164,12 @@ if __name__ == "__main__":
         search_config=SearchConfiguration(problem_type="min", generations=10, pool_size=32),
         dump_results="results.csv",
     )
-    results = tuner.start()
+    with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
+        results = tuner.start(task_timeout=20)
     best = results.get_best_result()
-    save_compiler_config("best.acf", best["params"])
+    user_space, ptxas_config = best["params"]
+    print(f"best config index: {user_space['config_idx']}")
+    save_compiler_config("best.acf", ptxas_config)
 ```
 
 ---

--- a/agent-skills/compileiq-run-search/SKILL.md
+++ b/agent-skills/compileiq-run-search/SKILL.md
@@ -39,10 +39,11 @@ the worker, size the configuration, and run the search safely.
 
 ## Worker selection
 
-Pass the **Worker class itself** to `Search(worker_type=...)`, not the enum
-(`docs/workers.md:12`):
+Pass either a built-in `WorkerTypes` enum value or the worker class itself to
+`Search(worker_type=...)`:
 
 ```python
+from compileiq.types import WorkerTypes
 from compileiq.worker import (
     MultiProcessWorker,    # default
     IsoMultiProcessWorker, # spawns fresh process per task; kill-safe
@@ -54,6 +55,7 @@ from compileiq.worker import (
 | Situation | Worker class | Why |
 |---|---|---|
 | GPU kernel that may hang, OOM, or leak CUDA context | **`IsoMultiProcessWorker`** | One fresh process per task; parent kills on `task_timeout`. Defaults to `fork`. (`docs/workers.md:42`) |
+| Triton mixed example on Blackwell-class GPUs | `WorkerTypes.ISOLATED` + `CIQ_PROCESS_MODE=spawn` | Isolates each evaluation and avoids leaking illegal memory access state across runs. |
 | Fast (<100ms), stateless objective | `MultiProcessWorker` (default) | Reuses a pool; lower overhead. Defaults to `forkserver`. |
 | Multi-node / multi-GPU cluster | `RayWorker` | User must set up Ray cluster + install compileiq on every worker. Both `num_workers` and `task_timeout` are ignored. (`docs/workers.md:79-91`) |
 | I/O-bound `async def` objective | `AsyncWorker` | Concurrency, not parallelism. Rare for GPU work. |
@@ -106,7 +108,7 @@ tuner = Search(
     objective_function=objective,
     search_space=PtxasSearchSpace(version="13.3", variant="att"),
     search_config=config,
-    worker_type=IsoMultiProcessWorker,                 # class, not enum
+    worker_type=IsoMultiProcessWorker,                 # or WorkerTypes.ISOLATED
     tracker_config=LoguruTrackerConfig(sink="optimization.log"),
     dump_results=Path("results.csv"),                  # ALWAYS set this
     cache_folder=None,                                  # default ~/.cache/compileiq

--- a/compileiq/core/executable/core-manifest.json
+++ b/compileiq/core/executable/core-manifest.json
@@ -7,14 +7,14 @@
   "pipeline_id": 53625600,
   "files": {
     "linux/aarch64/bin/_core": "sha256:a3e32c027b397b8c7e68b6d39bdd01d1877e0ed11008dab6444334277100007c",
-    "linux/aarch64/bin/core": "sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882",
+    "linux/aarch64/bin/core": "sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8",
     "linux/aarch64/lib/libciq.so": "sha256:7e798e4540905db1942be5d8a740b08390922b900a601afe4d43adf054ec5b7e",
     "linux/x86_64/bin/_core": "sha256:0fea2a15f0935c2c0c511822d3772a27a4695b3b7912aa089051ef9dea527d4c",
-    "linux/x86_64/bin/core": "sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882",
+    "linux/x86_64/bin/core": "sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8",
     "linux/x86_64/lib/libciq.so": "sha256:e49d1b0fbe196d0ca3f3aafc16db53823136d98b353d1c001768d459e3f2f04c",
     "win32/amd64/core.exe": "sha256:9b4f1a63193d2cad5787ed515f57d20ff0b62e52d687e9bb989d7f26d7ce7c53",
     "win32/amd64/libciq.dll": "sha256:37df95add866f884590ec5c70bce117650799b55d82da571ce75334ae060b6e3"
   },
   "source_manifest_sha256": "sha256:f447906f7d62d36fc62d8c88480e5ae1d6edad07ed7044ac2db3f533196aa558",
-  "core_lock": "sha256:17f57b4235307a848d8b465f87773b97e20f5ca485c97084f94ccb8f573d1282"
+  "core_lock": "sha256:c3c0d0f445778ca437e2ef7231562eeb38e9e99a22d974eb87463aaa6ec5a722"
 }

--- a/compileiq/core/executable/linux/aarch64/bin/core
+++ b/compileiq/core/executable/linux/aarch64/bin/core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882
-size 224
+oid sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8
+size 165

--- a/compileiq/core/executable/linux/x86_64/bin/core
+++ b/compileiq/core/executable/linux/x86_64/bin/core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882
-size 224
+oid sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8
+size 165

--- a/compileiq/search_spaces/resolver.py
+++ b/compileiq/search_spaces/resolver.py
@@ -16,11 +16,15 @@ Two ways to bypass the GitHub release path:
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+import datetime as dt
 import functools
 import hashlib
+import json
+import math
 import os
 import pathlib
 from typing import Literal
+import warnings
 
 import requests
 
@@ -44,6 +48,12 @@ SEARCH_SPACE_TAG_PREFIX_ENV_VAR = "CIQ_SS_TAG_PREFIX"
 # resolving "latest"; override via CIQ_SS_TAG_PREFIX.
 DEFAULT_SEARCH_SPACE_TAG_PREFIX = "search-spaces-"
 
+# Environment variable used to choose how long a resolved "latest" search-space
+# release tag can be reused from disk before checking GitHub again. Set to "0"
+# to disable the on-disk latest cache.
+LATEST_TAG_TTL_DAYS_ENV_VAR = "CIQ_SS_LATEST_TTL_DAYS"
+DEFAULT_LATEST_TAG_TTL_DAYS = 7.0
+
 # GitHub API host for release metadata and GitHub web host for release-asset
 # downloads.
 GH_API = "https://api.github.com"
@@ -56,6 +66,7 @@ _HTTP_TIMEOUT_SEC = 60
 _CHUNK_BYTES = 1 << 16
 # 1 MiB hash chunks avoid loading large artifacts into memory.
 _HASH_CHUNK_BYTES = 1 << 20
+_LATEST_TAG_CACHE_DIR = "latest-tags"
 
 
 @dataclass(frozen=True)
@@ -98,15 +109,92 @@ def _cache_root() -> pathlib.Path:
     return pathlib.Path(const._CACHE_DIR)
 
 
-@functools.lru_cache(maxsize=8)
-def _resolve_latest_tag(repo: str, tag_prefix: str) -> str:
-    """Resolve "latest" to a concrete release tag.
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
 
-    With no prefix, uses GitHub's ``/releases/latest`` endpoint. With a prefix
-    (single-repo topology where wheel and search-space tags share a namespace),
-    walks ``/releases`` and returns the first non-draft release whose tag
-    begins with the prefix.
-    """
+
+def _latest_tag_ttl_days() -> float:
+    """Return the configured latest-tag cache TTL in days."""
+    raw = os.getenv(LATEST_TAG_TTL_DAYS_ENV_VAR, str(DEFAULT_LATEST_TAG_TTL_DAYS))
+    try:
+        ttl_days = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{LATEST_TAG_TTL_DAYS_ENV_VAR} must be a non-negative number of days, got {raw!r}"
+        ) from exc
+    if not math.isfinite(ttl_days) or ttl_days < 0:
+        raise ValueError(
+            f"{LATEST_TAG_TTL_DAYS_ENV_VAR} must be a non-negative number of days, got {raw!r}"
+        )
+    return ttl_days
+
+
+def _latest_tag_cache_path(repo: str, tag_prefix: str) -> pathlib.Path:
+    """Return the repo/prefix-specific cache path for a latest-tag record."""
+    key = hashlib.sha256(f"{repo}\0{tag_prefix}".encode("utf-8")).hexdigest()
+    return _cache_root() / _LATEST_TAG_CACHE_DIR / f"{key}.json"
+
+
+def _read_latest_tag_cache(repo: str, tag_prefix: str) -> dict[str, object] | None:
+    """Load a matching latest-tag record, ignoring missing or invalid files."""
+    path = _latest_tag_cache_path(repo, tag_prefix)
+    try:
+        payload = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("repo") != repo or payload.get("tag_prefix") != tag_prefix:
+        return None
+    if not isinstance(payload.get("resolved_tag"), str):
+        return None
+    if not isinstance(payload.get("fetched_at"), str):
+        return None
+    return payload
+
+
+def _latest_tag_cache_age(record: dict[str, object]) -> dt.timedelta | None:
+    """Return the cache record age, or None when fetched_at is invalid."""
+    try:
+        fetched_at = dt.datetime.fromisoformat(str(record["fetched_at"]))
+    except (KeyError, ValueError):
+        return None
+    if fetched_at.tzinfo is None:
+        fetched_at = fetched_at.replace(tzinfo=dt.timezone.utc)
+    return _utc_now() - fetched_at
+
+
+def _latest_tag_cache_is_fresh(record: dict[str, object], ttl_days: float) -> bool:
+    """Return whether the cache record is within the configured TTL."""
+    age = _latest_tag_cache_age(record)
+    if age is None:
+        return False
+    return age <= dt.timedelta(days=ttl_days)
+
+
+def _write_latest_tag_cache(
+    repo: str,
+    tag_prefix: str,
+    resolved_tag: str,
+    ttl_days: float,
+) -> None:
+    """Persist the resolved latest tag atomically for later cold processes."""
+    path = _latest_tag_cache_path(repo, tag_prefix)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".part")
+    payload = {
+        "repo": repo,
+        "tag_prefix": tag_prefix,
+        "resolved_tag": resolved_tag,
+        "fetched_at": _utc_now().isoformat(),
+        "ttl_days": ttl_days,
+    }
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    tmp.replace(path)
+
+
+def _fetch_latest_tag_from_github(repo: str, tag_prefix: str) -> str:
+    """Resolve latest through GitHub without consulting the on-disk cache."""
     if tag_prefix:
         page = 1
         while True:
@@ -130,6 +218,39 @@ def _resolve_latest_tag(repo: str, tag_prefix: str) -> str:
     r = requests.get(f"{GH_API}/repos/{repo}/releases/latest", timeout=_HTTP_TIMEOUT_SEC)
     r.raise_for_status()
     return r.json()["tag_name"]
+
+
+@functools.lru_cache(maxsize=8)
+def _resolve_latest_tag(repo: str, tag_prefix: str) -> str:
+    """Resolve "latest" to a concrete release tag.
+
+    A fresh on-disk record is returned without a GitHub request. Missing or
+    expired records are refreshed from GitHub, then rewritten for future cold
+    processes. With no prefix, refresh uses GitHub's ``/releases/latest``
+    endpoint. With a prefix, refresh walks ``/releases`` and returns the first
+    non-draft, non-prerelease release whose tag begins with the prefix.
+    """
+    ttl_days = _latest_tag_ttl_days()
+    cached = _read_latest_tag_cache(repo, tag_prefix)
+    if ttl_days > 0 and cached is not None and _latest_tag_cache_is_fresh(cached, ttl_days):
+        return str(cached["resolved_tag"])
+
+    try:
+        resolved_tag = _fetch_latest_tag_from_github(repo, tag_prefix)
+    except Exception:
+        if ttl_days > 0 and cached is not None and _latest_tag_cache_age(cached) is not None:
+            warnings.warn(
+                f"Using stale cached latest search-space tag {cached['resolved_tag']!r} "
+                "because GitHub latest-tag resolution failed.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            return str(cached["resolved_tag"])
+        raise
+
+    if ttl_days > 0:
+        _write_latest_tag_cache(repo, tag_prefix, resolved_tag, ttl_days)
+    return resolved_tag
 
 
 def _cache_path(tag: str, sha256: str, filename: str) -> pathlib.Path:

--- a/dev/inspect_search_space_rate_limits.py
+++ b/dev/inspect_search_space_rate_limits.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Inspect search-space release rate-limit exposure.
+
+The online search-space resolver stores manifests and binaries on disk, but it
+must resolve tag="latest" to a concrete release tag before it can look in that
+cache. This script shows which GitHub REST API endpoint is involved, the
+current rate-limit bucket, and whether the resolved release is already cached.
+
+By default the script only calls the GitHub REST API for rate metadata and
+latest-tag resolution. It does not download manifests or search-space binaries.
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import datetime as dt
+import hashlib
+import json
+import math
+import os
+import pathlib
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+RELEASE_REPO_ENV_VAR = "CIQ_SEARCH_SPACES_REPO"
+DEFAULT_RELEASE_REPO = "NVIDIA/CompileIQ"
+LOCAL_DIR_ENV_VAR = "CIQ_SEARCH_SPACES_DIR"
+SEARCH_SPACE_TAG_PREFIX_ENV_VAR = "CIQ_SS_TAG_PREFIX"
+DEFAULT_SEARCH_SPACE_TAG_PREFIX = "search-spaces-"
+LATEST_TAG_TTL_DAYS_ENV_VAR = "CIQ_SS_LATEST_TTL_DAYS"
+DEFAULT_LATEST_TAG_TTL_DAYS = 7.0
+GH_API = "https://api.github.com"
+HTTP_TIMEOUT_SEC = 60
+HASH_CHUNK_BYTES = 1 << 20
+LATEST_TAG_CACHE_DIR = "latest-tags"
+
+
+@dataclass(frozen=True)
+class RateSnapshot:
+    limit: int | None
+    remaining: int | None
+    reset_epoch: int | None
+    used: int | None
+    resource: str | None
+
+
+@dataclass(frozen=True)
+class LatestResolution:
+    tag: str
+    api_calls: int
+    endpoint_kind: str
+    snapshot: RateSnapshot | None
+    source: str
+
+
+@dataclass(frozen=True)
+class LatestCacheStatus:
+    path: pathlib.Path
+    state: str
+    ttl_days: float
+    resolved_tag: str | None
+    age: dt.timedelta | None
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Inspect GitHub API rate-limit exposure for search-space retrieval."
+    )
+    parser.add_argument(
+        "--repo",
+        default=os.getenv(RELEASE_REPO_ENV_VAR, DEFAULT_RELEASE_REPO),
+        help=(
+            f"GitHub owner/repo to inspect. Defaults to {RELEASE_REPO_ENV_VAR} "
+            f"or {DEFAULT_RELEASE_REPO}."
+        ),
+    )
+    parser.add_argument(
+        "--tag",
+        default="latest",
+        help="Requested search-space release tag. Use a concrete tag to avoid latest lookup.",
+    )
+    parser.add_argument(
+        "--tag-prefix",
+        default=os.getenv(
+            SEARCH_SPACE_TAG_PREFIX_ENV_VAR,
+            DEFAULT_SEARCH_SPACE_TAG_PREFIX,
+        ),
+        help=(
+            f"Prefix used when resolving latest. Defaults to "
+            f"{SEARCH_SPACE_TAG_PREFIX_ENV_VAR} or "
+            f"{DEFAULT_SEARCH_SPACE_TAG_PREFIX!r}."
+        ),
+    )
+    parser.add_argument("--compiler", default="ptxas", help="Compiler key to inspect.")
+    parser.add_argument("--compiler-version", default="13.3", help="Compiler version to inspect.")
+    parser.add_argument("--variant", default="default", help="Search-space variant to inspect.")
+    parser.add_argument(
+        "--cache-root",
+        type=pathlib.Path,
+        default=pathlib.Path.home() / ".cache" / "compileiq",
+        help="CompileIQ cache root to inspect.",
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=5,
+        help="Maximum release-list pages to scan when resolving latest with a prefix.",
+    )
+    parser.add_argument(
+        "--no-network",
+        action="store_true",
+        help="Skip GitHub API calls and only explain the local/cache behavior.",
+    )
+    parser.add_argument(
+        "--hash-cache",
+        action="store_true",
+        help="Hash a cached binary to verify sha256. Size is checked either way.",
+    )
+    return parser.parse_args()
+
+
+def _github_token() -> str | None:
+    for name in ("GITHUB_TOKEN", "GH_TOKEN"):
+        token = os.getenv(name)
+        if token:
+            return token
+    return None
+
+
+def _latest_tag_ttl_days() -> float:
+    """Return the resolver's latest-tag cache TTL in days."""
+    raw = os.getenv(LATEST_TAG_TTL_DAYS_ENV_VAR, str(DEFAULT_LATEST_TAG_TTL_DAYS))
+    try:
+        ttl_days = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"{LATEST_TAG_TTL_DAYS_ENV_VAR} must be a non-negative number of days, got {raw!r}"
+        ) from exc
+    if not math.isfinite(ttl_days) or ttl_days < 0:
+        raise ValueError(
+            f"{LATEST_TAG_TTL_DAYS_ENV_VAR} must be a non-negative number of days, got {raw!r}"
+        )
+    return ttl_days
+
+
+def _latest_tag_cache_path(cache_root: pathlib.Path, repo: str, tag_prefix: str) -> pathlib.Path:
+    """Return the resolver-compatible latest-tag cache path for repo/prefix."""
+    key = hashlib.sha256(f"{repo}\0{tag_prefix}".encode("utf-8")).hexdigest()
+    return cache_root / LATEST_TAG_CACHE_DIR / f"{key}.json"
+
+
+def _read_latest_cache(path: pathlib.Path, repo: str, tag_prefix: str) -> dict[str, object] | None:
+    """Load a matching latest-tag cache record, ignoring malformed records."""
+    try:
+        payload = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("repo") != repo or payload.get("tag_prefix") != tag_prefix:
+        return None
+    if not isinstance(payload.get("resolved_tag"), str):
+        return None
+    if not isinstance(payload.get("fetched_at"), str):
+        return None
+    return payload
+
+
+def _latest_cache_age(record: dict[str, object]) -> dt.timedelta | None:
+    """Return a latest-tag cache record's age, if its timestamp is parseable."""
+    try:
+        fetched_at = dt.datetime.fromisoformat(str(record["fetched_at"]))
+    except (KeyError, ValueError):
+        return None
+    if fetched_at.tzinfo is None:
+        fetched_at = fetched_at.replace(tzinfo=dt.timezone.utc)
+    return dt.datetime.now(tz=dt.timezone.utc) - fetched_at
+
+
+def _latest_cache_status(
+    cache_root: pathlib.Path,
+    repo: str,
+    tag_prefix: str,
+    ttl_days: float,
+) -> LatestCacheStatus:
+    """Classify the latest-tag cache as disabled, missing, invalid, fresh, or expired."""
+    path = _latest_tag_cache_path(cache_root, repo, tag_prefix)
+    if ttl_days == 0:
+        return LatestCacheStatus(path, "disabled", ttl_days, None, None)
+
+    record = _read_latest_cache(path, repo, tag_prefix)
+    if record is None:
+        return LatestCacheStatus(path, "missing", ttl_days, None, None)
+
+    age = _latest_cache_age(record)
+    if age is None:
+        return LatestCacheStatus(path, "invalid", ttl_days, None, None)
+
+    state = "fresh" if age <= dt.timedelta(days=ttl_days) else "expired"
+    return LatestCacheStatus(path, state, ttl_days, str(record["resolved_tag"]), age)
+
+
+def _write_latest_cache(
+    cache_root: pathlib.Path,
+    repo: str,
+    tag_prefix: str,
+    resolved_tag: str,
+    ttl_days: float,
+) -> None:
+    """Write the latest-tag cache in the same format used by the resolver."""
+    path = _latest_tag_cache_path(cache_root, repo, tag_prefix)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".part")
+    payload = {
+        "repo": repo,
+        "tag_prefix": tag_prefix,
+        "resolved_tag": resolved_tag,
+        "fetched_at": dt.datetime.now(tz=dt.timezone.utc).isoformat(),
+        "ttl_days": ttl_days,
+    }
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    tmp.replace(path)
+
+
+def _headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "compileiq-search-space-rate-limit-inspector",
+    }
+    token = _github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _rate_snapshot(headers: Any) -> RateSnapshot:
+    def as_int(name: str) -> int | None:
+        value = headers.get(name)
+        if value is None:
+            return None
+        try:
+            return int(str(value))
+        except ValueError:
+            return None
+
+    return RateSnapshot(
+        limit=as_int("X-RateLimit-Limit"),
+        remaining=as_int("X-RateLimit-Remaining"),
+        reset_epoch=as_int("X-RateLimit-Reset"),
+        used=as_int("X-RateLimit-Used"),
+        resource=headers.get("X-RateLimit-Resource"),
+    )
+
+
+def _get_json(headers: dict[str, str], url: str) -> tuple[Any, RateSnapshot]:
+    """GET a GitHub JSON endpoint and return the response plus rate headers."""
+    request = Request(url, headers=headers)
+    try:
+        with urlopen(request, timeout=HTTP_TIMEOUT_SEC) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body), _rate_snapshot(response.headers)
+    except HTTPError as exc:
+        if exc.code in {403, 429}:
+            _print_http_limit_details(exc)
+        raise
+
+
+def _rate_limit(headers: dict[str, str]) -> tuple[dict[str, Any], RateSnapshot]:
+    """Fetch GitHub rate-limit metadata, preferring the primary core bucket."""
+    payload, snapshot = _get_json(headers, f"{GH_API}/rate_limit")
+    core = payload.get("resources", {}).get("core", {})
+    if core:
+        snapshot = RateSnapshot(
+            limit=core.get("limit"),
+            remaining=core.get("remaining"),
+            reset_epoch=core.get("reset"),
+            used=core.get("used"),
+            resource="core",
+        )
+    return payload, snapshot
+
+
+def _resolve_latest(
+    headers: dict[str, str],
+    repo: str,
+    tag_prefix: str,
+    max_pages: int,
+) -> LatestResolution:
+    """Resolve latest from GitHub and report which endpoint and call count were used."""
+    if tag_prefix:
+        for page in range(1, max_pages + 1):
+            url = f"{GH_API}/repos/{repo}/releases?per_page=100&page={page}"
+            releases, snapshot = _get_json(headers, url)
+            if not releases:
+                break
+            for release in releases:
+                tag = str(release.get("tag_name", ""))
+                if (
+                    tag.startswith(tag_prefix)
+                    and not release.get("draft", False)
+                    and not release.get("prerelease", False)
+                ):
+                    return LatestResolution(
+                        tag=tag,
+                        api_calls=page,
+                        endpoint_kind="/repos/{repo}/releases",
+                        snapshot=snapshot,
+                        source="github",
+                    )
+        raise RuntimeError(
+            f"No non-draft, non-prerelease tag with prefix {tag_prefix!r} "
+            f"found in first {max_pages} release pages."
+        )
+
+    url = f"{GH_API}/repos/{repo}/releases/latest"
+    release, snapshot = _get_json(headers, url)
+    return LatestResolution(
+        tag=str(release["tag_name"]),
+        api_calls=1,
+        endpoint_kind="/repos/{repo}/releases/latest",
+        snapshot=snapshot,
+        source="github",
+    )
+
+
+def _format_reset(reset_epoch: int | None) -> str:
+    if reset_epoch is None:
+        return "unknown"
+    reset = dt.datetime.fromtimestamp(reset_epoch, tz=dt.timezone.utc)
+    now = dt.datetime.now(tz=dt.timezone.utc)
+    seconds = max(0, int((reset - now).total_seconds()))
+    minutes, rem = divmod(seconds, 60)
+    return f"{reset.isoformat()} UTC ({minutes}m {rem}s from now)"
+
+
+def _format_rate(snapshot: RateSnapshot | None) -> str:
+    if snapshot is None:
+        return "unknown"
+    parts = [
+        f"resource={snapshot.resource or 'unknown'}",
+        f"remaining={_fmt_int(snapshot.remaining)}",
+        f"limit={_fmt_int(snapshot.limit)}",
+        f"used={_fmt_int(snapshot.used)}",
+        f"reset={_format_reset(snapshot.reset_epoch)}",
+    ]
+    return ", ".join(parts)
+
+
+def _fmt_int(value: int | None) -> str:
+    return "unknown" if value is None else str(value)
+
+
+def _format_age(age: dt.timedelta | None) -> str:
+    if age is None:
+        return "unknown"
+    total_seconds = max(0, int(age.total_seconds()))
+    days, rem = divmod(total_seconds, 24 * 60 * 60)
+    hours, rem = divmod(rem, 60 * 60)
+    minutes, _ = divmod(rem, 60)
+    if days:
+        return f"{days}d {hours}h {minutes}m"
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def _load_cached_manifest(cache_root: pathlib.Path, tag: str) -> dict[str, Any] | None:
+    """Load a cached manifest for a concrete tag when it is present."""
+    manifest_path = cache_root / tag / "manifest.json"
+    if not manifest_path.exists():
+        return None
+    return json.loads(manifest_path.read_text())
+
+
+def _find_entry(
+    manifest: dict[str, Any],
+    compiler: str,
+    compiler_version: str,
+    variant: str,
+) -> dict[str, Any]:
+    """Find the manifest entry matching the requested compiler, version, and variant."""
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise KeyError("manifest has no entries list")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        if (
+            entry.get("compiler") == compiler
+            and entry.get("compiler_version") == compiler_version
+            and entry.get("variant", "default") == variant
+        ):
+            return entry
+    raise KeyError(
+        f"no manifest entry for compiler={compiler!r}, "
+        f"compiler_version={compiler_version!r}, variant={variant!r}"
+    )
+
+
+def _cached_entry_status(
+    cache_root: pathlib.Path,
+    tag: str,
+    entry: dict[str, Any],
+    hash_cache: bool,
+) -> list[str]:
+    """Describe whether the manifest entry's binary is present and valid locally."""
+    filename = str(entry["filename"])
+    sha256 = str(entry["sha256"])
+    size_bytes = int(entry["size_bytes"])
+    cached = cache_root / tag / f"{sha256[:12]}_{filename}"
+    lines = [f"  binary cache: {cached}"]
+    if not cached.exists():
+        lines.append("  binary status: missing, resolver would download the asset")
+        return lines
+
+    actual_size = cached.stat().st_size
+    if actual_size == size_bytes:
+        lines.append(f"  binary size: ok ({actual_size} bytes)")
+    else:
+        lines.append(
+            f"  binary size: mismatch, expected {size_bytes}, found {actual_size}"
+        )
+
+    if hash_cache:
+        actual_sha = _sha256(cached)
+        if actual_sha == sha256:
+            lines.append("  binary sha256: ok")
+        else:
+            lines.append(f"  binary sha256: mismatch, expected {sha256}, found {actual_sha}")
+    else:
+        lines.append("  binary sha256: not checked, pass --hash-cache to verify")
+    return lines
+
+
+def _sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(HASH_CHUNK_BYTES), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _cached_latest_candidates(
+    cache_root: pathlib.Path,
+    tag_prefix: str,
+    compiler: str,
+    compiler_version: str,
+    variant: str,
+) -> list[str]:
+    """List cached concrete tags that could satisfy a latest request offline."""
+    if not cache_root.exists():
+        return []
+    tags: list[str] = []
+    for manifest_path in sorted(cache_root.glob("*/manifest.json")):
+        tag = manifest_path.parent.name
+        if tag_prefix and not tag.startswith(tag_prefix):
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text())
+            _find_entry(manifest, compiler, compiler_version, variant)
+        except Exception:
+            continue
+        tags.append(tag)
+    return tags
+
+
+def _print_http_limit_details(error: HTTPError) -> None:
+    """Print rate-limit headers attached to a GitHub 403 or 429 response."""
+    print("GitHub returned a possible rate-limit response:", file=sys.stderr)
+    print(f"  status: {error.code}", file=sys.stderr)
+    print(f"  url: {error.url}", file=sys.stderr)
+    print(f"  rate: {_format_rate(_rate_snapshot(error.headers))}", file=sys.stderr)
+    retry_after = error.headers.get("Retry-After")
+    if retry_after:
+        print(f"  retry-after: {retry_after} seconds", file=sys.stderr)
+
+
+def _print_settings(args: argparse.Namespace) -> None:
+    token_state = "present" if _github_token() else "not present"
+    print("Resolver settings")
+    print(f"  repo: {args.repo}")
+    print(f"  requested tag: {args.tag}")
+    print(f"  tag prefix: {args.tag_prefix!r}")
+    print(f"  cache root: {args.cache_root}")
+    print(f"  local mirror env: {os.getenv(LOCAL_DIR_ENV_VAR) or 'not set'}")
+    print(f"  GitHub token env: {token_state}")
+    print()
+
+
+def _print_latest_cache(status: LatestCacheStatus) -> None:
+    print("Latest tag cache")
+    print(f"  path: {status.path}")
+    print(f"  state: {status.state}")
+    print(f"  ttl: {status.ttl_days:g} days")
+    print(f"  age: {_format_age(status.age)}")
+    print(f"  resolved tag: {status.resolved_tag or 'unknown'}")
+    would_call = status.state != "fresh"
+    print(f"  would call GitHub for latest: {'yes' if would_call else 'no'}")
+    print()
+
+
+def _print_behavior(args: argparse.Namespace, latest: LatestResolution | None) -> None:
+    print("Resolver network behavior")
+    if os.getenv(LOCAL_DIR_ENV_VAR):
+        print(f"  {LOCAL_DIR_ENV_VAR} is set, so the resolver should skip GitHub.")
+        print()
+        return
+
+    if args.tag != "latest":
+        print("  Concrete tag requested, so latest-tag GitHub API lookup is skipped.")
+        print("  Manifest and binary downloads use github.com release assets only if absent.")
+        print()
+        return
+
+    endpoint = latest.endpoint_kind if latest else (
+        "/repos/{repo}/releases" if args.tag_prefix else "/repos/{repo}/releases/latest"
+    )
+    calls = latest.api_calls if latest else "at least 1"
+    source = latest.source if latest else "unknown"
+    print(f"  tag='latest' uses GitHub REST endpoint: {endpoint}")
+    print(f"  API calls per cold Python process for latest-tag resolution: {calls}")
+    print(f"  latest-tag source for this run: {source}")
+    print("  The resolver memoizes that lookup only inside the current Python process.")
+    print("  Disk-cached manifests/binaries are checked after latest resolves to a concrete tag.")
+    print()
+
+
+def _print_cache(args: argparse.Namespace, resolved_tag: str | None) -> None:
+    print("Local cache")
+    if resolved_tag is None:
+        if args.tag == "latest":
+            candidates = _cached_latest_candidates(
+                args.cache_root,
+                args.tag_prefix,
+                args.compiler,
+                args.compiler_version,
+                args.variant,
+            )
+            if candidates:
+                print("  cached candidate tags with matching manifest entry:")
+                for tag in candidates:
+                    print(f"    {tag}")
+            else:
+                print("  no cached matching manifests found")
+            print("  freshness cannot be confirmed without resolving latest.")
+        else:
+            print("  not inspected")
+        print()
+        return
+
+    manifest_path = args.cache_root / resolved_tag / "manifest.json"
+    print(f"  manifest cache: {manifest_path}")
+    manifest = _load_cached_manifest(args.cache_root, resolved_tag)
+    if manifest is None:
+        print("  manifest status: missing, resolver would download manifest.json")
+        print()
+        return
+    print("  manifest status: present")
+    entry = _find_entry(manifest, args.compiler, args.compiler_version, args.variant)
+    for line in _cached_entry_status(args.cache_root, resolved_tag, entry, args.hash_cache):
+        print(line)
+    print()
+
+
+def _print_estimate(snapshot: RateSnapshot | None, api_calls: int | None) -> None:
+    print("Rate-limit estimate")
+    if api_calls == 0:
+        print("  latest-tag API calls per cold resolver process: 0")
+        print("  GitHub REST primary quota is not consumed by this latest-tag path.")
+        print()
+        return
+    if api_calls is None:
+        print("  latest-tag API calls per cold resolver process: not measured")
+        print("  With tag='latest', expect at least 1 GitHub REST call per cold process.")
+        print("  Run without --no-network to calculate the current page count and quota.")
+        print()
+        return
+
+    print(f"  observed GitHub rate bucket: {_format_rate(snapshot)}")
+    if snapshot and snapshot.remaining is not None:
+        remaining_processes = snapshot.remaining // api_calls
+        print(
+            "  cold resolver processes before this bucket reaches zero: "
+            f"about {remaining_processes}"
+        )
+    else:
+        print("  remaining process estimate unavailable because rate headers were absent")
+    print(
+        "  Note: release asset downloads are outside this REST core bucket, "
+        "but GitHub/network layers can still throttle large downloads separately."
+    )
+    print()
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        ttl_days = _latest_tag_ttl_days()
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    _print_settings(args)
+
+    resolved_tag: str | None = args.tag if args.tag != "latest" else None
+    latest: LatestResolution | None = None
+    rate_before: RateSnapshot | None = None
+    latest_cache: LatestCacheStatus | None = None
+    use_latest_cache = args.tag == "latest" and not os.getenv(LOCAL_DIR_ENV_VAR)
+    if use_latest_cache:
+        latest_cache = _latest_cache_status(args.cache_root, args.repo, args.tag_prefix, ttl_days)
+        _print_latest_cache(latest_cache)
+        if latest_cache.state == "fresh":
+            resolved_tag = latest_cache.resolved_tag
+
+    if args.no_network:
+        print("GitHub rate bucket")
+        print("  skipped because --no-network was supplied")
+        print()
+    else:
+        headers = _headers()
+        try:
+            _, rate_before = _rate_limit(headers)
+            print("GitHub rate bucket before latest probe")
+            print(f"  {_format_rate(rate_before)}")
+            print()
+
+            if use_latest_cache and latest_cache and latest_cache.state == "fresh":
+                latest = LatestResolution(
+                    tag=str(latest_cache.resolved_tag),
+                    api_calls=0,
+                    endpoint_kind="on-disk latest cache",
+                    snapshot=rate_before,
+                    source="on-disk latest cache",
+                )
+            elif use_latest_cache:
+                try:
+                    latest = _resolve_latest(headers, args.repo, args.tag_prefix, args.max_pages)
+                except (HTTPError, RuntimeError, URLError) as exc:
+                    can_use_stale = (
+                        latest_cache is not None
+                        and latest_cache.resolved_tag is not None
+                        and latest_cache.state == "expired"
+                    )
+                    if can_use_stale:
+                        print(
+                            "WARNING: using stale cached latest tag because GitHub "
+                            f"latest resolution failed: {exc}",
+                            file=sys.stderr,
+                        )
+                        latest = LatestResolution(
+                            tag=latest_cache.resolved_tag,
+                            api_calls=0,
+                            endpoint_kind="stale on-disk latest cache",
+                            snapshot=rate_before,
+                            source="stale on-disk latest cache",
+                        )
+                    else:
+                        raise
+                if latest.source == "github" and ttl_days > 0:
+                    _write_latest_cache(
+                        args.cache_root,
+                        args.repo,
+                        args.tag_prefix,
+                        latest.tag,
+                        ttl_days,
+                    )
+            if latest is not None:
+                resolved_tag = latest.tag
+                print("Latest resolution")
+                print(f"  resolved tag: {latest.tag}")
+                print(f"  endpoint kind: {latest.endpoint_kind}")
+                print(f"  source: {latest.source}")
+                print(f"  API calls used for this resolution: {latest.api_calls}")
+                print(f"  rate after latest probe: {_format_rate(latest.snapshot)}")
+                print()
+        except HTTPError as exc:
+            print(f"ERROR: GitHub request failed: {exc}", file=sys.stderr)
+            return 2
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        except URLError as exc:
+            print(
+                f"ERROR: GitHub request failed before receiving a response: {exc}",
+                file=sys.stderr,
+            )
+            return 2
+
+    _print_behavior(args, latest)
+    _print_cache(args, resolved_tag)
+
+    if args.tag == "latest" and not os.getenv(LOCAL_DIR_ENV_VAR):
+        api_calls = latest.api_calls if latest else None
+        snapshot = latest.snapshot if latest else rate_before
+    else:
+        api_calls = 0
+        snapshot = rate_before
+    _print_estimate(snapshot, api_calls)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/install.md
+++ b/docs/install.md
@@ -83,5 +83,6 @@ for the full layout and authoring conventions.
 | CIQ_PROCESS_MODE | "forkserver" | str | User can set this to "fork" to better separate processes and deal with threads. `IsoMultiProcessWorker` uses `fork` as the default.
 | CIQ_SEARCH_SPACES_DIR | unset | path | Reads compiler search-space `manifest.json` and `.bin` files from a local mirror instead of GitHub.
 | CIQ_SEARCH_SPACES_REPO | NVIDIA/CompileIQ | str | GitHub repository used for search-space release lookups, useful for staging or a future dedicated asset repo.
+| CIQ_SS_LATEST_TTL_DAYS | 7 | float | Reuses the cached GitHub `latest` search-space release tag for this many days, reducing anonymous REST API calls that can be throttled on shared IPs. Set to `0` to check GitHub every time.
 | CIQ_CORE_BINARY | unset | path | Uses an explicit core executable for local core development instead of the bundled binary.
 | CIQ_CORE_MANIFEST | unset | path | Optionally verifies `CIQ_CORE_BINARY` against a local core manifest rooted next to the platform directories.

--- a/docs/triton_example.md
+++ b/docs/triton_example.md
@@ -1,34 +1,57 @@
 # Tuning PTXAS for your Triton kernel
 
-In this section, we will build on an existing Triton tutorial kernel and apply PTXAS ACFs.
+This section shows how to apply CompileIQ-generated PTXAS ACFs to a Triton
+kernel. The basic example uses a fixed-config illustrative matmul kernel and
+searches only PTXAS controls. The companion mixed example shows how to search
+Triton launch/configuration knobs and PTXAS controls together.
 
 > The example code and supporting files can be found [in our repo here](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/triton_example/triton_ptx.py).
 
-## Matmul Triton Tutorial
+> Examples may become stale as triton or the compiler improve, and these examples are simple in nature, meant to teach you how to incorporate CompileIQ into your existing code
 
-The original kernel for the Triton tutorial can be found in [the Triton repository](https://github.com/triton-lang/triton/blob/v3.6.0/python/tutorials/03-matrix-multiplication.py).
+## Fixed-config matmul example
 
-Our goal is to apply CompileIQ on top of an existing matmul kernel to optimize runtime. Our changes are minimal: we do not modify the kernel code itself. Let’s walk through the integration before looking at the full objective function.
-
-### Specific Changes to Triton
-
-First, Triton is JIT-compiled, so we need to force recompilation for each ACF we try. An easy way to do this is by setting the environment variable `TRITON_ALWAYS_COMPILE`.
-
-Second, at the time of writing, Triton ships with its own PTXAS binary for ease of use. However, we need PTXAS 13.3 or higher to use CompileIQ’s ACF support. Therefore, we also override Triton’s default PTXAS with a local version via `TRITON_PTXAS_PATH`.
-
-You can do this programmatically with:
+The basic `triton_ptx.py` example keeps the Triton kernel configuration fixed:
 
 ```python
-import os
-os.environ["TRITON_ALWAYS_COMPILE"] = "1"
-os.environ["TRITON_PTXAS_PATH"] = "path/to/bin/ptxas"
+BLOCK_M = 32
+BLOCK_N = 64
+BLOCK_K = 32
+NUM_WARPS = 4
+NUM_STAGES = 3
 ```
 
-> For blackwell overwrites use: `TRITON_PTXAS_BLACKWELL_PATH` instead of `TRITON_PTXAS_PATH`
+It then tunes only the PTXAS compiler controls for that kernel and matrix
+shape. The example uses exact-tile `4096 x 4096` inputs, so `M`, `N`, and `K`
+must be divisible by the block sizes.
 
-Finally, we need to pass the ACF file to Triton so it can forward it to PTXAS. Triton already supports this via `ptx_options` when launching your kernel:
+## Specific changes for Triton
+
+Triton is JIT-compiled, so force recompilation for each ACF:
 
 ```python
+os.environ["TRITON_ALWAYS_COMPILE"] = "1"
+```
+
+Triton ships its own PTXAS binary. CompileIQ ACF support requires
+PTXAS 13.3 or newer, so point Triton at the expected local `ptxas`. Set both
+environment variables when targeting systems where Triton may select a
+Blackwell-specific PTXAS path:
+
+```python
+ptxas_path = shutil.which("ptxas")
+if ptxas_path is None:
+    raise RuntimeError("ptxas not found in PATH.")
+
+os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
+```
+
+Pass the ACF to Triton through the `ptx_options` kernel-launch keyword:
+
+```python
+ptxas_options = f"--apply-controls={controls_path}" if controls_path else None
+
 matmul_kernel[grid](
     a,
     b,
@@ -42,170 +65,160 @@ matmul_kernel[grid](
     b.stride(1),
     c.stride(0),
     c.stride(1),
-    ACTIVATION=activation,
-    ptx_options=f"--apply-controls={ptx_acf_filename}",
+    BLOCK_M=BLOCK_M,
+    BLOCK_N=BLOCK_N,
+    BLOCK_K=BLOCK_K,
+    num_warps=NUM_WARPS,
+    num_stages=NUM_STAGES,
+    ptx_options=ptxas_options,
 )
 ```
 
-> You can optionally use the `PTX_OPTIONS` environment variable to pass in the `--apply-controls` flag instead of explicitly adding it to your kernel calls.
+> You can optionally use the `PTX_OPTIONS` environment variable to pass in the `--apply-controls` flag instead of explicitly adding it to your kernel calls. Note that this will be applied globally
 
 ### Building the objective function
 
-With everything in place, we can now build our objective function:
+The objective writes each sampled CompileIQ config to a temporary `.acf` file,
+passes that file to the Triton launch, checks correctness against Torch, and
+only then benchmarks runtime:
 
 ```python
-def objective(ptx_acf: str) -> float:
-    """
-    Our objective will minimize runtime. It applies the given
-    ACF to the kernel, verifies output correctness, and
-    benchmarks the runtime.
-    """
-
-    ptxas_path = shutil.which("ptxas")  # Ensures Triton picks up the expected ptxas
+def objective(config) -> float:
+    ptxas_path = shutil.which("ptxas")
     if ptxas_path is None:
         raise RuntimeError("ptxas not found in PATH.")
 
     os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+    os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
-    a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
-    b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
+    a = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
+    b = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
 
-    with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as tmp_acf_file:
-        save_compiler_config(tmp_acf_file.name, ptx_acf)
+    with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
+        save_compiler_config(f.name, config)
+        triton_out = matmul(a, b, f.name)
+        torch_out = torch.matmul(a, b)
 
-        triton_output = matmul(a, b, tmp_acf_file.name)
-        torch_output = torch.matmul(a, b)
+        if not torch.allclose(triton_out, torch_out, atol=1e-2, rtol=0):
+            return INVALID_SCORE
 
-        # Validating output
-        if not torch.allclose(triton_output, torch_output, atol=1e-2, rtol=0):
-            runtime = INVALID_SCORE
-        else:
-            # Benchmarking Advanced Controls File
-            runtime = triton.testing.do_bench(
-                lambda: matmul(a, b, tmp_acf_file.name),
-                warmup=100,
-                rep=1000,
-                return_mode="mean",
-            )
-
-    return runtime
+        return triton.testing.do_bench(
+            lambda: matmul(a, b, f.name),
+            warmup=100,
+            rep=1000,
+            return_mode="mean",
+        )
 ```
 
-Here’s what the function does:
+This objective follows the guardrails in the [Safety Section](compilers_overview.md#safety--correctness-read-this-first):
 
-* Sets environment variables for Triton to avoid caching and to use the expected PTXAS.
-* Creates a temporary file containing the sampled ACF from CompileIQ.
-* Passes that file into the `matmul` function from the [original tutorial](https://github.com/triton-lang/triton/blob/v3.6.0/python/tutorials/03-matrix-multiplication.py). This function is modified to pass the PTXAS CLI option `--apply-controls`, as described above.
-* Validating result correctness against Torch's implementation.
-* Performing benchmarking to get the runtime, only if the correctness test passed.
+* Force recompilation so each ACF can affect generated code.
+* Use an explicit PTXAS 13.3+ path.
+* Validate correctness before timing.
+* Return `INVALID_SCORE` for wrong answers.
 
-This objective is following all guidelines from our [Safety Section](compilers_overview.md#safety--correctness-read-this-first).
+### Expanding the search to different matrix sizes
 
-#### Expanding the search to different matrix sizes
+In the basic example, the search is specific to `4096 x 4096` matmul with the
+fixed block sizes above. If you want to support multiple sizes, you have a few
+options:
 
-In this example, we tune PTXAS controls for a specific matrix size of 512×512. If you want to support multiple sizes, you have a few options:
+* Run a separate search for each size.
+* Benchmark and validate all matrix sizes inside the objective and return an aggregate score.
+* Use a [multi-objective search](getting_started.md#multi-objective-searches) and return one score per size.
 
-* Perform one different search for each size
-* Benchmark and validate all matrix sizes inside the objective and return the mean, or only return a score if the ACF showed gains on most or all of the benchmarks
-* Perform a [multi-objective search](getting_started.md#multi-objective-searches) where you return one score for each of the sizes you want to support.
+### A note on performance
 
-#### A Note on Performance
-
-It is important that all measurements performed during the search are reliable. We provide helper functionality to lock clocks which will help with reproducibility and runtime stability.
+Reliable latency measurements are important during the search. CompileIQ
+provides a helper to lock clocks:
 
 ```python
 from compileiq.utils.gpu import gpu_benchmark_mode
 
 with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
-    results = tuner.start()
+    results = tuner.start(task_timeout=20)
 ```
 
-Because we are using the multiprocessing worker that only works locally, we can lock the clocks once before starting the search. If you are using Ray on multiple machines, you may want to either lock the clocks beforehand or use `gpu_benchmark_mode` inside the objective function to make sure the clocks are locked for each individual evaluation regardless of where it will execute.
+Because the default multiprocessing worker runs locally, you can lock clocks
+once before starting the search. If you use Ray across multiple machines, lock
+clocks before the run or use `gpu_benchmark_mode` inside the objective function
+so each remote evaluation runs under the same clock policy.
 
-## Expanding to Mixed-Search Spaces
+## Expanding to mixed search spaces
 
-Besides tuning PTXAS, CompileIQ often finds its best results when co-tuning other hyperparameters that matter to the application. In this example, Triton already does a good job with its own autotuner. As an example, we can disable the autotuner and expose those parameters to CompileIQ as part of the search space.
-
-First, remove the autotune decorator and keep the configs in an accessible location:
+Besides tuning PTXAS, CompileIQ can co-tune application parameters. The
+`mixed_triton.py` example searches a user-defined index into a list of Triton
+configs plus the PTXAS search space:
 
 ```python
 TRITON_CONFIGS = [
-    {
-        "block_size_m": 128,
-        "block_size_n": 256,
-        "block_size_k": 64,
-        "group_size_m": 8,
-        "num_stages": 3,
-        "num_warps": 8,
-    },
-    {
-        "block_size_m": 64,
-        "block_size_n": 256,
-        "block_size_k": 32,
-        "group_size_m": 8,
-        "num_stages": 4,
-        "num_warps": 4,
-    }, 
-    ... 
-    ]
+    {"block_m": 32, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 256, "block_k": 64, "stages": 3, "warps": 8},
+]
+
+search_space = [
+    {"config_idx": ss.range(0, len(TRITON_CONFIGS) - 1)},
+    PtxasSearchSpace(version=cuda_version),
+]
 ```
 
-We can now define a mixed search space containing the user space and PTX space.
+The objective receives a list with one entry per search-space component:
 
 ```python
-user_space = {"config_idx": ss.range(0, len(TRITON_CONFIGS) - 1)}
-ptx_space = PtxasSearchSpace(version=cuda_version)
-
-search_space_config = [user_space, ptx_space]
-
-tuner = Search(
-    objective_function=objective,
-    search_space=search_space_config,
-    search_config=main_config,
-)
-```
-
-Here we create a range parameter that indexes into `TRITON_CONFIGS`.
-
-In the objective function, we now receive a list with the user space and PTX space sampled separately. We adjust the objective to read the index and pass the selected config to the kernel:
-
-```python
-
-def objective(mixed_ss: list[dict, str]) -> float:
-
-    user_space, ptx_acf = mixed_ss
-    config_idx = user_space["config_idx"]
+def objective(mixed_config: list) -> float:
+    user_space, ptxas_config = mixed_config
+    cfg = TRITON_CONFIGS[user_space["config_idx"]]
 
     ...
 
-    triton_output = matmul(a, b, tmp_acf_file.name, **TRITON_CONFIGS[config_idx])
-
+    with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
+        save_compiler_config(f.name, ptxas_config)
+        triton_output = matmul(a, b, f.name, cfg)
 ```
 
-With this adjustment, CompileIQ can tune both PTX and user-space parameters together !
+Mixed-search results keep that same list shape in `best["params"]`. Unpack it
+before saving the ACF:
+
+```python
+best = results.get_best_result()
+user_space, ptxas_config = best["params"]
+
+print(f"Best Triton config index: {user_space['config_idx']}")
+save_compiler_config("best_matmul.acf", ptxas_config)
+```
+
+```python
+tuner = Search(
+    objective_function=objective,
+    search_space=search_space,
+    search_config=config,
+)
+```
 
 ### Expanding even further
 
-The example above is illustrative and reuses the pre-defined configurations for the Triton matmul example. Alternatively, you can search over block and group sizes independently.
-
-As an example, you could expose each option as a CompileIQ parameter:
+The example above indexes into a curated list of supported Triton configs.
+Alternatively, you can search over block and launch parameters directly:
 
 ```python
-
 user_space = {
-    "block_size_m": ss.range(16, 128, 16),
-    "block_size_n": ss.range(16, 256, 16),
-    "block_size_k": ss.range(16, 128, 16),
-    "group_size_m": ss.choice([4, 8, 16]),
-    "num_stages": ss.choice([2, 3, 4, 5]),
-    "num_warps": ss.choice([2, 4, 8]),
+    "block_m": ss.range(16, 128, 16),
+    "block_n": ss.range(16, 256, 16),
+    "block_k": ss.range(16, 128, 16),
+    "stages": ss.choice([2, 3, 4, 5]),
+    "warps": ss.choice([2, 4, 8]),
 }
 
-ptx_space = PtxasSearchSpace(version=cuda_version)
-
-search_space_config = [user_space, ptx_space]
-
+search_space = [
+    user_space,
+    PtxasSearchSpace(version=cuda_version),
+]
 ```
 
-Although this approach might require longer searches, it provides better visibility into how each combination behaves. You might even find good solutions where you least expect them.
+This approach may require longer searches, but it gives CompileIQ visibility
+into each parameter combination.
+

--- a/examples/compilers/triton_example/README.md
+++ b/examples/compilers/triton_example/README.md
@@ -6,7 +6,7 @@ Optimize Triton kernels with CompileIQ's PTXAS controls.
 
 ### Basic PTX Controls (`triton_ptx.py`)
 
-Optimizes a matmul kernel by tuning PTXAS compiler settings.
+Optimizes a fixed-config matmul kernel by tuning PTXAS compiler settings.
 
 ```bash
 python triton_ptx.py
@@ -31,7 +31,7 @@ python mixed_triton.py
 
 ## Output
 
-Both scripts generate `best_matmul.acf` - use with Triton's `ptx_options`:
+Both scripts generate `best_matmul.acf` - use with Triton's `ptx_options` or through `PTXAS_OPTIONS` env var:
 
 ```python
 kernel[grid](..., ptx_options="--apply-controls=best_matmul.acf")

--- a/examples/compilers/triton_example/mixed_triton.py
+++ b/examples/compilers/triton_example/mixed_triton.py
@@ -22,74 +22,100 @@ import triton.language as tl
 import compileiq.search_spaces.base as ss
 from compileiq.ciq import Search
 from compileiq.search_spaces.compilers import PtxasSearchSpace
-from compileiq.types import INVALID_SCORE, SearchConfiguration
+from compileiq.types import INVALID_SCORE, SearchConfiguration, WorkerTypes
+from compileiq.utils.gpu import gpu_benchmark_mode
 from compileiq.utils.helpers import save_compiler_config
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
 # Triton configs to search over (user-defined space)
 TRITON_CONFIGS = [
-    {"block_m": 128, "block_n": 256, "block_k": 64, "group_m": 8, "stages": 3, "warps": 8},
-    {"block_m": 64, "block_n": 256, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
-    {"block_m": 128, "block_n": 128, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
-    {"block_m": 128, "block_n": 64, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
-    {"block_m": 64, "block_n": 128, "block_k": 32, "group_m": 8, "stages": 4, "warps": 4},
+    {"block_m": 32, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 64, "block_k": 32, "stages": 3, "warps": 4},
+    {"block_m": 64, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 128, "block_k": 32, "stages": 4, "warps": 4},
+    {"block_m": 128, "block_n": 256, "block_k": 64, "stages": 3, "warps": 8},
 ]
+
+
+def is_blackwell_gpu() -> bool:
+    """Return True for Blackwell-class CUDA devices."""
+    major, _ = torch.cuda.get_device_capability(DEVICE)
+    return major >= 10
 
 
 @triton.jit
 def matmul_kernel(
-    a_ptr, b_ptr, c_ptr,
-    M, N, K,
-    stride_am, stride_ak, stride_bk, stride_bn, stride_cm, stride_cn,
-    BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr, ACTIVATION: tl.constexpr,
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
 ):
-    """Standard tiled matmul: C = A @ B"""
+    """Simple exact-tile matmul: C = A @ B."""
     pid = tl.program_id(0)
-    num_pid_m, num_pid_n = tl.cdiv(M, BLOCK_M), tl.cdiv(N, BLOCK_N)
-    num_pid_in_group = GROUP_M * num_pid_n
-    group_id = pid // num_pid_in_group
-    first_pid_m = group_id * GROUP_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
-    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
-    pid_n = (pid % num_pid_in_group) // group_size_m
+    num_pid_n = N // BLOCK_N
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
 
-    offs_am = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
-    offs_bn = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_k = tl.arange(0, BLOCK_K)
-    a_ptrs = a_ptr + offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
-    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
-        acc = tl.dot(a, b, acc)
-        a_ptrs += BLOCK_K * stride_ak
-        b_ptrs += BLOCK_K * stride_bk
+    for k in range(0, K, BLOCK_K):
+        k_idxs = k + offs_k
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + k_idxs[None, :] * stride_ak
+        b_ptrs = b_ptr + k_idxs[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        acc += tl.dot(a, b)
 
     c = acc.to(tl.float16)
-    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    c_ptrs = c_ptr + offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn
-    tl.store(c_ptrs, c, mask=(offs_cm[:, None] < M) & (offs_cn[None, :] < N))
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, c)
 
 
-def matmul(a, b, acf_path: str, cfg: dict):
-    """Run matmul with custom Triton config and PTXAS controls."""
+def matmul(a, b, controls_path: str, cfg: dict):
+    """Run the exact-tile matmul with custom Triton config and PTXAS controls."""
     assert a.shape[1] == b.shape[0] and a.is_contiguous()
     M, K = a.shape
     _, N = b.shape
+    assert M % cfg["block_m"] == 0
+    assert N % cfg["block_n"] == 0
+    assert K % cfg["block_k"] == 0
     c = torch.empty((M, N), device=a.device, dtype=torch.float16)
-    grid = (triton.cdiv(M, cfg["block_m"]) * triton.cdiv(N, cfg["block_n"]),)
+    grid = ((M // cfg["block_m"]) * (N // cfg["block_n"]),)
+    ptxas_options = f"--apply-controls={controls_path}" if controls_path else None
     matmul_kernel[grid](
-        a, b, c, M, N, K,
-        a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1),
-        BLOCK_M=cfg["block_m"], BLOCK_N=cfg["block_n"], BLOCK_K=cfg["block_k"],
-        GROUP_M=cfg["group_m"], ACTIVATION="",
-        num_stages=cfg["stages"], num_warps=cfg["warps"],
-        ptx_options=f"--apply-controls={acf_path}",
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=cfg["block_m"],
+        BLOCK_N=cfg["block_n"],
+        BLOCK_K=cfg["block_k"],
+        num_stages=cfg["stages"],
+        num_warps=cfg["warps"],
+        ptx_options=ptxas_options,
     )
     return c
 
@@ -99,11 +125,13 @@ def objective(mixed_config: list) -> float:
     user_space, ptxas_config = mixed_config
     cfg = TRITON_CONFIGS[user_space["config_idx"]]
 
-    os.environ["TRITON_PTXAS_PATH"] = shutil.which("ptxas")
+    ptxas_path = shutil.which("ptxas")
+    os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+    os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
-    a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
-    b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
+    a = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
+    b = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
 
     with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
         save_compiler_config(f.name, ptxas_config)
@@ -134,18 +162,28 @@ def main():
 
     # Configure and run search
     config = SearchConfiguration(problem_type="min", generations=5, pool_size=32)
+    search_kwargs = {}
+    if is_blackwell_gpu():
+        # This specific example may cause Illegal Memory accesses
+        # We leverage fully isolated processes to prevent leaking across runs
+        os.environ["CIQ_PROCESS_MODE"] = "spawn"
+        search_kwargs["worker_type"] = WorkerTypes.ISOLATED
+
     tuner = Search(
         objective_function=objective,
         search_space=search_space,
         search_config=config,
+        **search_kwargs,
     )
-    results = tuner.start()
+    with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
+        results = tuner.start(task_timeout=20)
 
     # Save best result
     best = results.get_best_result()
+    user_space, ptxas_config = best["params"]
     print(f"Best runtime: {best['score_1']:.4f} ms")
-    print(f"Best Triton config index: {best['user_space']['config_idx']}")
-    save_compiler_config("best_matmul.acf", best["params"])
+    print(f"Best Triton config index: {user_space['config_idx']}")
+    save_compiler_config("best_matmul.acf", ptxas_config)
 
 
 if __name__ == "__main__":

--- a/examples/compilers/triton_example/triton_ptx.py
+++ b/examples/compilers/triton_example/triton_ptx.py
@@ -1,7 +1,7 @@
 """
-CompileIQ Triton Example: Optimize matmul kernel with PTXAS controls.
+CompileIQ Triton Example: Optimize a fixed-config matmul kernel with PTXAS controls.
 
-This example uses Triton's matmul kernel from the official tutorials and
+This example uses an illustrative Triton matmul kernel and
 applies CompileIQ to search for optimal PTXAS compiler configurations.
 
 Usage:
@@ -26,22 +26,13 @@ from compileiq.utils.gpu import gpu_benchmark_mode
 
 DEVICE = triton.runtime.driver.active.get_active_torch_device()
 
+BLOCK_M = 32
+BLOCK_N = 64
+BLOCK_K = 32
+NUM_WARPS = 4
+NUM_STAGES = 3
 
-# Matmul kernel from Triton tutorials (simplified config list)
-@triton.autotune(
-    configs=[
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 256, "BLOCK_K": 64, "GROUP_M": 8}, num_stages=3, num_warps=8
-        ),
-        triton.Config(
-            {"BLOCK_M": 64, "BLOCK_N": 256, "BLOCK_K": 32, "GROUP_M": 8}, num_stages=4, num_warps=4
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 32, "GROUP_M": 8}, num_stages=4, num_warps=4
-        ),
-    ],
-    key=["M", "N", "K"],
-)
+
 @triton.jit
 def matmul_kernel(
     a_ptr,
@@ -59,47 +50,42 @@ def matmul_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr,
-    ACTIVATION: tl.constexpr,
 ):
-    """Standard tiled matmul: C = A @ B"""
+    """Simple exact-tile matmul: C = A @ B."""
     pid = tl.program_id(0)
-    num_pid_m, num_pid_n = tl.cdiv(M, BLOCK_M), tl.cdiv(N, BLOCK_N)
-    num_pid_in_group = GROUP_M * num_pid_n
-    group_id = pid // num_pid_in_group
-    first_pid_m = group_id * GROUP_M
-    group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
-    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
-    pid_n = (pid % num_pid_in_group) // group_size_m
+    num_pid_n = N // BLOCK_N
+    pid_m = pid // num_pid_n
+    pid_n = pid % num_pid_n
 
-    offs_am = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)) % M
-    offs_bn = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)) % N
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
     offs_k = tl.arange(0, BLOCK_K)
-    a_ptrs = a_ptr + offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak
-    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn
 
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_K, other=0.0)
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_K, other=0.0)
-        acc = tl.dot(a, b, acc)
-        a_ptrs += BLOCK_K * stride_ak
-        b_ptrs += BLOCK_K * stride_bk
+    for k in range(0, K, BLOCK_K):
+        k_idxs = k + offs_k
+        a_ptrs = a_ptr + offs_m[:, None] * stride_am + k_idxs[None, :] * stride_ak
+        b_ptrs = b_ptr + k_idxs[:, None] * stride_bk + offs_n[None, :] * stride_bn
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        acc += tl.dot(a, b)
 
     c = acc.to(tl.float16)
-    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    c_ptrs = c_ptr + offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn
-    tl.store(c_ptrs, c, mask=(offs_cm[:, None] < M) & (offs_cn[None, :] < N))
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, c)
 
 
-def matmul(a, b, acf_path: str):
-    """Run matmul with custom PTXAS controls."""
+def matmul(a, b, controls_path: str):
+    """Run the fixed-config matmul with custom PTXAS controls."""
     assert a.shape[1] == b.shape[0] and a.is_contiguous()
     M, K = a.shape
     _, N = b.shape
+    assert M % BLOCK_M == 0
+    assert N % BLOCK_N == 0
+    assert K % BLOCK_K == 0
     c = torch.empty((M, N), device=a.device, dtype=torch.float16)
-    grid = lambda META: (triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),)  # noqa: E731
+    grid = ((M // BLOCK_M) * (N // BLOCK_N),)
+    ptxas_options = f"--apply-controls={controls_path}" if controls_path else None
     matmul_kernel[grid](
         a,
         b,
@@ -113,19 +99,25 @@ def matmul(a, b, acf_path: str):
         b.stride(1),
         c.stride(0),
         c.stride(1),
-        ACTIVATION="",
-        ptx_options=f"--apply-controls={acf_path}",
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+        num_warps=NUM_WARPS,
+        num_stages=NUM_STAGES,
+        ptx_options=ptxas_options,
     )
     return c
 
 
-def objective(config: str) -> float:
+def objective(config) -> float:
     """Evaluate a PTXAS config: verify correctness, then benchmark."""
-    os.environ["TRITON_PTXAS_PATH"] = shutil.which("ptxas")
+    ptxas_path = shutil.which("ptxas")
+    os.environ["TRITON_PTXAS_PATH"] = ptxas_path
+    os.environ["TRITON_PTXAS_BLACKWELL_PATH"] = ptxas_path
     os.environ["TRITON_ALWAYS_COMPILE"] = "1"
 
-    a = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
-    b = torch.rand((512, 512), device=DEVICE, dtype=torch.float16) - 0.5
+    a = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
+    b = torch.rand((4096, 4096), device=DEVICE, dtype=torch.float16) - 0.5
 
     with tempfile.NamedTemporaryFile(suffix=".acf", delete=True) as f:
         save_compiler_config(f.name, config)
@@ -149,7 +141,7 @@ def main():
     assert float(cuda_version) >= 13.3, "CompileIQ requires CUDA 13.3+"
 
     # Configure and run search
-    config = SearchConfiguration(problem_type="min", generations=5, pool_size=32)
+    config = SearchConfiguration(problem_type="min", generations=5)
     tuner = Search(
         objective_function=objective,
         search_space=PtxasSearchSpace(version=cuda_version),
@@ -161,7 +153,7 @@ def main():
     # Please set the clock speeds according to your GPU capabilities.
     # If using multiple machines with Ray, use `gpu_benchmark_mode` inside the `objective` function.
     with gpu_benchmark_mode(clock_mhz=1965, raise_on_failure=False):
-        results = tuner.start()
+        results = tuner.start(task_timeout=20)
 
     # Save best result
     best = results.get_best_result()

--- a/tests/unit/search_spaces/test_resolver.py
+++ b/tests/unit/search_spaces/test_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 import json
 from unittest.mock import MagicMock
@@ -16,6 +17,8 @@ BIN_BYTES = b"PTX-SS-13.3-DEFAULT" * 200
 BIN_SHA = hashlib.sha256(BIN_BYTES).hexdigest()
 BIN_FILENAME = "ptxas13.3_search_space.bin"
 TAG = "search-spaces-2026.04.27"
+OLD_TAG = "search-spaces-2026.01.01"
+NOW = dt.datetime(2026, 6, 15, 12, 0, tzinfo=dt.timezone.utc)
 
 
 def _manifest_payload(
@@ -45,10 +48,37 @@ def _manifest_payload(
     )
 
 
+def _set_now(monkeypatch, now: dt.datetime = NOW) -> None:
+    monkeypatch.setattr(resolver, "_utc_now", lambda: now)
+
+
+def _write_latest_cache(
+    repo: str,
+    tag_prefix: str,
+    resolved_tag: str,
+    fetched_at: dt.datetime = NOW,
+    ttl_days: float = resolver.DEFAULT_LATEST_TAG_TTL_DAYS,
+) -> None:
+    cache = resolver._latest_tag_cache_path(repo, tag_prefix)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    cache.write_text(
+        json.dumps(
+            {
+                "repo": repo,
+                "tag_prefix": tag_prefix,
+                "resolved_tag": resolved_tag,
+                "fetched_at": fetched_at.isoformat(),
+                "ttl_days": ttl_days,
+            }
+        )
+    )
+
+
 @pytest.fixture(autouse=True)
 def reset_lru(monkeypatch):
     resolver._resolve_latest_tag.cache_clear()
     monkeypatch.delenv(resolver.LOCAL_DIR_ENV_VAR, raising=False)
+    monkeypatch.delenv(resolver.LATEST_TAG_TTL_DAYS_ENV_VAR, raising=False)
     # Force the no-prefix code path by default so tests can target
     # /releases/latest cleanly. test_default_tag_prefix_used_when_unset and
     # test_tag_prefix_filters_releases override to exercise the prefix path.
@@ -99,6 +129,13 @@ def fake_http(monkeypatch):
 
     monkeypatch.setattr(resolver.requests, "get", fake_get)
     return handlers, _stream_response, _json_response
+
+
+def _add_asset_routes(handlers, stream, repo: str, tag: str = TAG) -> None:
+    handlers[f"{resolver.GH_DL}/{repo}/releases/download/{tag}/manifest.json"] = stream(
+        _manifest_payload(tag=tag).encode()
+    )
+    handlers[f"{resolver.GH_DL}/{repo}/releases/download/{tag}/{BIN_FILENAME}"] = stream(BIN_BYTES)
 
 
 def test_air_gap_short_circuit(tmp_path, monkeypatch):
@@ -336,6 +373,137 @@ def test_latest_resolution_memoized_per_process(fake_http):
         {"tag_name": "WRONG"}, status=500
     )
     resolver.resolve("ptxas", "13.3")  # would raise if cache miss re-fetched
+
+
+def test_fresh_latest_disk_cache_skips_github_latest(fake_http, monkeypatch):
+    _set_now(monkeypatch)
+    handlers, stream, _jsn = fake_http
+    repo = resolver._release_repo()
+    _write_latest_cache(repo, "", TAG, fetched_at=NOW)
+    _add_asset_routes(handlers, stream, repo, TAG)
+
+    path = resolver.resolve("ptxas", "13.3")
+
+    assert path.read_bytes() == BIN_BYTES
+    assert TAG in str(path)
+
+
+def test_missing_latest_disk_cache_refreshes_and_writes(fake_http, monkeypatch):
+    _set_now(monkeypatch)
+    handlers, stream, jsn = fake_http
+    repo = resolver._release_repo()
+    handlers[f"{resolver.GH_API}/repos/{repo}/releases/latest"] = jsn({"tag_name": TAG})
+    _add_asset_routes(handlers, stream, repo, TAG)
+
+    resolver.resolve("ptxas", "13.3")
+
+    cache = json.loads(resolver._latest_tag_cache_path(repo, "").read_text())
+    assert cache["repo"] == repo
+    assert cache["tag_prefix"] == ""
+    assert cache["resolved_tag"] == TAG
+    assert cache["fetched_at"] == NOW.isoformat()
+    assert cache["ttl_days"] == resolver.DEFAULT_LATEST_TAG_TTL_DAYS
+
+
+def test_expired_latest_disk_cache_refreshes_and_updates(fake_http, monkeypatch):
+    _set_now(monkeypatch)
+    handlers, stream, jsn = fake_http
+    repo = resolver._release_repo()
+    stale_time = NOW - dt.timedelta(days=8)
+    _write_latest_cache(repo, "", OLD_TAG, fetched_at=stale_time)
+    handlers[f"{resolver.GH_API}/repos/{repo}/releases/latest"] = jsn({"tag_name": TAG})
+    _add_asset_routes(handlers, stream, repo, TAG)
+
+    path = resolver.resolve("ptxas", "13.3")
+
+    cache = json.loads(resolver._latest_tag_cache_path(repo, "").read_text())
+    assert path.read_bytes() == BIN_BYTES
+    assert TAG in str(path)
+    assert cache["resolved_tag"] == TAG
+    assert cache["fetched_at"] == NOW.isoformat()
+
+
+@pytest.mark.parametrize("status", [403, 429, 500])
+def test_expired_latest_disk_cache_uses_stale_on_github_failure(
+    fake_http,
+    monkeypatch,
+    status,
+):
+    _set_now(monkeypatch)
+    handlers, stream, jsn = fake_http
+    repo = resolver._release_repo()
+    stale_time = NOW - dt.timedelta(days=8)
+    _write_latest_cache(repo, "", OLD_TAG, fetched_at=stale_time)
+    handlers[f"{resolver.GH_API}/repos/{repo}/releases/latest"] = jsn({"message": "nope"}, status)
+    _add_asset_routes(handlers, stream, repo, OLD_TAG)
+
+    with pytest.warns(RuntimeWarning, match="Using stale cached latest search-space tag"):
+        path = resolver.resolve("ptxas", "13.3")
+
+    assert path.read_bytes() == BIN_BYTES
+    assert OLD_TAG in str(path)
+
+
+def test_github_failure_without_latest_disk_cache_raises(fake_http):
+    handlers, _stream, jsn = fake_http
+    repo = resolver._release_repo()
+    handlers[f"{resolver.GH_API}/repos/{repo}/releases/latest"] = jsn({"message": "nope"}, 500)
+
+    with pytest.raises(requests.HTTPError):
+        resolver.resolve("ptxas", "13.3")
+
+
+def test_latest_disk_cache_can_be_disabled(fake_http, monkeypatch):
+    _set_now(monkeypatch)
+    monkeypatch.setenv(resolver.LATEST_TAG_TTL_DAYS_ENV_VAR, "0")
+    handlers, stream, jsn = fake_http
+    repo = resolver._release_repo()
+    _write_latest_cache(repo, "", OLD_TAG, fetched_at=NOW)
+    handlers[f"{resolver.GH_API}/repos/{repo}/releases/latest"] = jsn({"tag_name": TAG})
+    _add_asset_routes(handlers, stream, repo, TAG)
+
+    path = resolver.resolve("ptxas", "13.3")
+
+    cache = json.loads(resolver._latest_tag_cache_path(repo, "").read_text())
+    assert path.read_bytes() == BIN_BYTES
+    assert TAG in str(path)
+    assert cache["resolved_tag"] == OLD_TAG
+
+
+@pytest.mark.parametrize("value", ["nope", "-1", "inf"])
+def test_invalid_latest_cache_ttl_raises(monkeypatch, value):
+    monkeypatch.setenv(resolver.LATEST_TAG_TTL_DAYS_ENV_VAR, value)
+
+    with pytest.raises(ValueError, match=resolver.LATEST_TAG_TTL_DAYS_ENV_VAR):
+        resolver.resolve("ptxas", "13.3")
+
+
+def test_latest_disk_cache_key_includes_repo_and_prefix():
+    default = resolver._latest_tag_cache_path("NVIDIA/CompileIQ", "search-spaces-")
+    other_repo = resolver._latest_tag_cache_path("example/search-spaces-test", "search-spaces-")
+    other_prefix = resolver._latest_tag_cache_path("NVIDIA/CompileIQ", "booster-packs-")
+
+    assert default != other_repo
+    assert default != other_prefix
+    assert other_repo != other_prefix
+
+
+def test_air_gap_ignores_latest_cache_ttl(tmp_path, monkeypatch):
+    air_gap = tmp_path / "ag"
+    air_gap.mkdir()
+    (air_gap / BIN_FILENAME).write_bytes(BIN_BYTES)
+    (air_gap / "manifest.json").write_text(_manifest_payload())
+    monkeypatch.setenv(resolver.LOCAL_DIR_ENV_VAR, str(air_gap))
+    monkeypatch.setenv(resolver.LATEST_TAG_TTL_DAYS_ENV_VAR, "invalid")
+    monkeypatch.setattr(
+        resolver.requests,
+        "get",
+        lambda *a, **kw: pytest.fail(f"network used despite {resolver.LOCAL_DIR_ENV_VAR}"),
+    )
+
+    path = resolver.resolve("ptxas", "13.3")
+
+    assert path == air_gap / BIN_FILENAME
 
 
 def test_default_tag_prefix_used_when_unset(fake_http, monkeypatch):


### PR DESCRIPTION
Backports selected `main` fixes and release-adjacent docs/CI updates for CompileIQ 1.0.2:

- Cache `tag="latest"` search-space release resolution on disk to reduce repeated GitHub REST API calls from cold processes.
- Quote Linux core wrapper path handling so installed-wheel searches can start the bundled core from install paths containing spaces.
- Include the CI workflow fix that keeps required CI eligible for PR-copy branches even when the change includes docs-only paths.
- Include public docs/contribution/template polish and Triton example fixes that are already on `main`.