### PR TITLE
Handle score-less diagnostic CSV inputs

### DIFF
--- a/agent-skills/compileiq-debug/scripts/diagnose_csv.py
+++ b/agent-skills/compileiq-debug/scripts/diagnose_csv.py
@@ -9,6 +9,7 @@ Prints a generation-summary table and flags one or more of:
 - INCREASING_INVALID_RATE  (mutation arm spreading bad configs)
 - STALLED_CONVERGENCE      (no improvement in best score over recent gens)
 - HIGH_VARIANCE            (validation-time noise; check GPU clocks)
+- NO_SCORE_COLUMN          (generation present but no score_1 or score column)
 - HEALTHY                  (none of the above)
 
 Exit code = number of flagged pathologies (0 = healthy).
@@ -41,6 +42,9 @@ def diagnose(df: pd.DataFrame) -> Diagnosis:
 
     if "score_1" not in df.columns and "score" in df.columns:
         df = df.rename(columns={"score": "score_1"})
+    elif "score_1" not in df.columns:
+        return Diagnosis(["NO_SCORE_COLUMN"], pd.DataFrame(),
+                         ["CSV missing 'score_1' or 'score' column."])
 
     df = df.copy()
     df["score_numeric"] = pd.to_numeric(df["score_1"], errors="coerce")

--- a/tests/unit/test_diagnose_csv.py
+++ b/tests/unit/test_diagnose_csv.py
@@ -1,0 +1,40 @@
+import importlib.util
+from pathlib import Path
+
+import pandas as pd
+
+
+def _load_diagnose_csv():
+    script_path = (
+        Path(__file__).parents[2]
+        / "agent-skills"
+        / "compileiq-debug"
+        / "scripts"
+        / "diagnose_csv.py"
+    )
+    spec = importlib.util.spec_from_file_location("diagnose_csv", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_diagnose_flags_generation_csv_without_score_column():
+    diagnose_csv = _load_diagnose_csv()
+    df = pd.DataFrame({"generation": [0], "foo": [1]})
+
+    diagnosis = diagnose_csv.diagnose(df)
+
+    assert diagnosis.flags == ["NO_SCORE_COLUMN"]
+    assert diagnosis.summary.empty
+    assert "score_1" in diagnosis.notes[0]
+
+
+def test_diagnose_accepts_legacy_score_column_alias():
+    diagnose_csv = _load_diagnose_csv()
+    df = pd.DataFrame({"generation": [0], "score": [1.0]})
+
+    diagnosis = diagnose_csv.diagnose(df)
+
+    assert diagnosis.flags == ["HEALTHY"]


### PR DESCRIPTION
## Summary
- return a structured `NO_SCORE_COLUMN` diagnosis when diagnostic CSV input has `generation` but no `score_1` or `score` column
- keep the existing legacy `score` to `score_1` alias behavior
- add regression coverage for the missing-score and alias paths

## Validation
- `PYTHONPATH=$PWD /Users/akent/Documents/2026-06-26-bug-triage/CompileIQ/.venv/bin/python -m pytest --confcutdir=tests/unit tests/unit/test_diagnose_csv.py -q`
