### PR TITLE
Reject malformed legacy config values cleanly

### DIFF
--- a/compileiq/types.py
+++ b/compileiq/types.py
@@ -683,7 +683,12 @@ class SearchConfiguration(BaseModel, extra="forbid"):
             if "seek_minimum" in key:
                 config_dict["problem_type"] = ProblemType.MIN if val == "True" else ProblemType.MAX
             elif key in available_fields:
-                config_dict[key] = ast.literal_eval(val)
+                try:
+                    config_dict[key] = ast.literal_eval(val)
+                except (SyntaxError, ValueError) as exc:
+                    raise ValueError(
+                        f"Invalid value for legacy configuration field {key!r}: {val!r}"
+                    ) from exc
             else:
                 warnings.warn(f"Configuration {key} is going to be ignored")
 

--- a/tests/unit/test_search_configuration.py
+++ b/tests/unit/test_search_configuration.py
@@ -181,6 +181,16 @@ class TestLegacyRoundTrip:
         with pytest.raises(ValueError, match="extension .config"):
             SearchConfiguration.from_legacy("not_a_config.txt")
 
+    def test_from_legacy_rejects_malformed_supported_field_value(self, tmp_path):
+        """Malformed supported-field values should fail at the parser boundary."""
+        config_path = tmp_path / "test.config"
+        config_path.write_text("(generations . 1+)\n")
+
+        with pytest.raises(ValueError, match="Invalid value.*generations") as excinfo:
+            SearchConfiguration.from_legacy(str(config_path))
+
+        assert isinstance(excinfo.value.__cause__, SyntaxError)
+
     def test_to_legacy_contains_seek_minimum(self):
         """The core binary reads 'seek_minimum', not 'problem_type'.
         Verify the key name translation happens."""


### PR DESCRIPTION
## Summary
- reject malformed supported-field values in legacy search configuration files with a clear `ValueError`
- include the affected field and value while preserving the original parser exception as the cause
- add regression coverage for malformed `.config` values

## Validation
- `PYTHONPATH=$PWD /Users/akent/Documents/2026-06-26-bug-triage/CompileIQ/.venv/bin/python -m pytest --confcutdir=tests/unit tests/unit/test_search_configuration.py::TestLegacyRoundTrip::test_from_legacy_rejects_malformed_supported_field_value -q`
