### PR TITLE
Fix knockout handling and bundle corrected core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,23 @@ jobs:
         run: |
           cd "$RUNNER_TEMP"
           python "$GITHUB_WORKSPACE/.github/scripts/smoke_test_compileiq_wheel.py"
+      - name: Smoke encrypted search space through installed wheel
+        shell: bash
+        run: |
+          cd "$RUNNER_TEMP"
+          python -c 'import sys, urllib.request; urllib.request.urlretrieve(sys.argv[1], sys.argv[2])' \
+            "https://github.com/NVIDIA/CompileIQ/releases/download/search-spaces-2026.08.14/ptxas13.4_search_space.bin" \
+            "$RUNNER_TEMP/ptxas13.4_search_space.bin"
+          python "$GITHUB_WORKSPACE/dev/smoke_test_encrypted_search_space.py" \
+            --search-space "$RUNNER_TEMP/ptxas13.4_search_space.bin" \
+            --output-dir "$RUNNER_TEMP/encrypted-search-space-smoke" \
+            --mode both \
+            --samples 4 \
+            --pool-size 6 \
+            --cull-size 2 \
+            --workers 1 \
+            --expected-sha256 9a232adcc36a6451a4a30f3fe1dbfb29c4476b7b324bcec87bc0f5cc30bbf70d \
+            --expected-size 13904
       - name: Upload smoke-tested wheel artifact
         uses: actions/upload-artifact@v6
         with:

--- a/Makefile
+++ b/Makefile
@@ -237,11 +237,12 @@ inspect-search-space-release: ## Inspect draft Search Space release before publi
 		--json tagName,name,isDraft,isPrerelease,targetCommitish,assets,body \
 		--template 'tag: {{.tagName}}{{"\n"}}title: {{.name}}{{"\n"}}draft: {{.isDraft}}{{"\n"}}prerelease: {{.isPrerelease}}{{"\n"}}target: {{.targetCommitish}}{{"\n"}}assets:{{"\n"}}{{range .assets}}  - {{.name}}{{"\n"}}{{end}}{{"\n"}}body:{{"\n"}}{{.body}}{{"\n"}}'
 
-# Publish the validated draft, then explicitly clear GitHub "Latest".
-# GitHub ignores make_latest while a release is still a draft, so keep this as
-# two API calls.
+# Publish the validated draft without changing GitHub "Latest". Repositories
+# with immutable releases seal a release as it is published, so both fields
+# must be updated in the same API call.
 publish-search-space-release: ## Publish draft Search Space release with make_latest=false
-	@if [ "$(CONFIRM_PUBLISH_RELEASE)" != "false" ]; then \
+	@set -eu; \
+	if [ "$(CONFIRM_PUBLISH_RELEASE)" != "false" ]; then \
 		printf 'Type %s to publish: ' "$(SS_RELEASE_TAG)"; \
 		read confirmation; \
 		if [ "$$confirmation" != "$(SS_RELEASE_TAG)" ]; then \
@@ -253,19 +254,20 @@ publish-search-space-release: ## Publish draft Search Space release with make_la
 	test -n "$$release_id" || (echo "ERROR: could not find release $(SS_RELEASE_TAG)" >&2; exit 1); \
 	gh api --method PATCH "repos/NVIDIA/CompileIQ/releases/$$release_id" \
 		-F draft=false \
-		--silent; \
-	gh api --method PATCH "repos/NVIDIA/CompileIQ/releases/$$release_id" \
 		-f make_latest=false \
-		--silent; \
-	echo "PASS: Published $(SS_RELEASE_TAG) with make_latest=false."
+		--silent
+	@$(MAKE) --no-print-directory check-search-space-published SS_RELEASE_TAG="$(SS_RELEASE_TAG)"
+	@echo "PASS: Published $(SS_RELEASE_TAG) with make_latest=false."
 
 clear-search-space-latest: ## Clear GitHub Latest marker from a Search Space release
-	@release_id="$$(gh release view "$(SS_RELEASE_TAG)" --repo NVIDIA/CompileIQ --json databaseId --jq .databaseId)"; \
+	@set -eu; \
+	release_id="$$(gh release view "$(SS_RELEASE_TAG)" --repo NVIDIA/CompileIQ --json databaseId --jq .databaseId)"; \
 	test -n "$$release_id" || (echo "ERROR: could not find release $(SS_RELEASE_TAG)" >&2; exit 1); \
 	gh api --method PATCH "repos/NVIDIA/CompileIQ/releases/$$release_id" \
 		-f make_latest=false \
-		--silent; \
-	echo "PASS: Cleared GitHub Latest marker for $(SS_RELEASE_TAG)."
+		--silent
+	@$(MAKE) --no-print-directory check-search-space-published SS_RELEASE_TAG="$(SS_RELEASE_TAG)"
+	@echo "PASS: Cleared GitHub Latest marker for $(SS_RELEASE_TAG)."
 
 # Confirm the published release is no longer a draft and is not GitHub "Latest".
 check-search-space-published: ## Confirm published Search Space release is not Latest
@@ -396,11 +398,12 @@ inspect-booster-pack-release: ## Inspect draft Booster Pack release before publi
 		--json tagName,name,isDraft,isPrerelease,targetCommitish,assets,body \
 		--template 'tag: {{.tagName}}{{"\n"}}title: {{.name}}{{"\n"}}draft: {{.isDraft}}{{"\n"}}prerelease: {{.isPrerelease}}{{"\n"}}target: {{.targetCommitish}}{{"\n"}}assets:{{"\n"}}{{range .assets}}  - {{.name}}{{"\n"}}{{end}}{{"\n"}}body:{{"\n"}}{{.body}}{{"\n"}}'
 
-# Publish the validated draft, then explicitly clear GitHub "Latest".
-# GitHub ignores make_latest while a release is still a draft, so keep this as
-# two API calls.
+# Publish the validated draft without changing GitHub "Latest". Repositories
+# with immutable releases seal a release as it is published, so both fields
+# must be updated in the same API call.
 publish-booster-pack-release: ## Publish draft Booster Pack release with make_latest=false
-	@if [ "$(CONFIRM_PUBLISH_RELEASE)" != "false" ]; then \
+	@set -eu; \
+	if [ "$(CONFIRM_PUBLISH_RELEASE)" != "false" ]; then \
 		printf 'Type %s to publish: ' "$(BOOSTER_RELEASE_TAG)"; \
 		read confirmation; \
 		if [ "$$confirmation" != "$(BOOSTER_RELEASE_TAG)" ]; then \
@@ -412,19 +415,20 @@ publish-booster-pack-release: ## Publish draft Booster Pack release with make_la
 	test -n "$$release_id" || (echo "ERROR: could not find release $(BOOSTER_RELEASE_TAG)" >&2; exit 1); \
 	gh api --method PATCH "repos/NVIDIA/CompileIQ/releases/$$release_id" \
 		-F draft=false \
-		--silent; \
-	gh api --method PATCH "repos/NVIDIA/CompileIQ/releases/$$release_id" \
 		-f make_latest=false \
-		--silent; \
-	echo "PASS: Published $(BOOSTER_RELEASE_TAG) with make_latest=false."
+		--silent
+	@$(MAKE) --no-print-directory check-booster-pack-published BOOSTER_RELEASE_TAG="$(BOOSTER_RELEASE_TAG)"
+	@echo "PASS: Published $(BOOSTER_RELEASE_TAG) with make_latest=false."
 
 clear-booster-pack-latest: ## Clear GitHub Latest marker from a Booster Pack release
-	@release_id="$$(gh release view "$(BOOSTER_RELEASE_TAG)" --repo NVIDIA/CompileIQ --json databaseId --jq .databaseId)"; \
+	@set -eu; \
+	release_id="$$(gh release view "$(BOOSTER_RELEASE_TAG)" --repo NVIDIA/CompileIQ --json databaseId --jq .databaseId)"; \
 	test -n "$$release_id" || (echo "ERROR: could not find release $(BOOSTER_RELEASE_TAG)" >&2; exit 1); \
 	gh api --method PATCH "repos/NVIDIA/CompileIQ/releases/$$release_id" \
 		-f make_latest=false \
-		--silent; \
-	echo "PASS: Cleared GitHub Latest marker for $(BOOSTER_RELEASE_TAG)."
+		--silent
+	@$(MAKE) --no-print-directory check-booster-pack-published BOOSTER_RELEASE_TAG="$(BOOSTER_RELEASE_TAG)"
+	@echo "PASS: Cleared GitHub Latest marker for $(BOOSTER_RELEASE_TAG)."
 
 # Confirm the published release is no longer a draft and is not GitHub "Latest".
 check-booster-pack-published: ## Confirm published Booster Pack release is not Latest

--- a/compileiq/core/executable/core-manifest.json
+++ b/compileiq/core/executable/core-manifest.json
@@ -1,20 +1,20 @@
 {
   "schema_version": 2,
-  "core_commit": "92581f1aab1c1ccc37614ff8242a474e4468d2cd",
+  "core_commit": "a5a0b8b9414ea62d1d4f6d6bca8dd8904f9518bd",
   "core_ref": "main",
   "core_tag": null,
-  "built_at": "2026-06-04T06:23:17Z",
-  "pipeline_id": 53625600,
+  "built_at": "2026-08-14T22:16:52Z",
+  "pipeline_id": 62778772,
   "files": {
-    "linux/aarch64/bin/_core": "sha256:a3e32c027b397b8c7e68b6d39bdd01d1877e0ed11008dab6444334277100007c",
-    "linux/aarch64/bin/core": "sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8",
+    "linux/aarch64/bin/_core": "sha256:7000aebea4b608457d2b0896fb5ee3cd6abd067f2374f2e9f9fe2e7b95fc5e61",
+    "linux/aarch64/bin/core": "sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882",
     "linux/aarch64/lib/libciq.so": "sha256:7e798e4540905db1942be5d8a740b08390922b900a601afe4d43adf054ec5b7e",
-    "linux/x86_64/bin/_core": "sha256:0fea2a15f0935c2c0c511822d3772a27a4695b3b7912aa089051ef9dea527d4c",
-    "linux/x86_64/bin/core": "sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8",
+    "linux/x86_64/bin/_core": "sha256:32f510aa8600c6c001a2da516aa0023b26b5326b71f6ee3dbb8b3406af20d18e",
+    "linux/x86_64/bin/core": "sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882",
     "linux/x86_64/lib/libciq.so": "sha256:e49d1b0fbe196d0ca3f3aafc16db53823136d98b353d1c001768d459e3f2f04c",
-    "win32/amd64/core.exe": "sha256:9b4f1a63193d2cad5787ed515f57d20ff0b62e52d687e9bb989d7f26d7ce7c53",
+    "win32/amd64/core.exe": "sha256:aa32eeb9457fb52e524035061e0f5c234f38b9199b846180fb41e29244ac8cd7",
     "win32/amd64/libciq.dll": "sha256:37df95add866f884590ec5c70bce117650799b55d82da571ce75334ae060b6e3"
   },
-  "source_manifest_sha256": "sha256:f447906f7d62d36fc62d8c88480e5ae1d6edad07ed7044ac2db3f533196aa558",
-  "core_lock": "sha256:c3c0d0f445778ca437e2ef7231562eeb38e9e99a22d974eb87463aaa6ec5a722"
+  "source_manifest_sha256": "sha256:ce9f73dc8384d5c9725b2d7f099ad6d7d8e7fed27ba8e4790c249b05e4636c46",
+  "core_lock": "sha256:0bc59bcd0864ce77dcae75aa00af3f7d641737e9abd0bd3cdb21c78425f127aa"
 }

--- a/compileiq/core/executable/linux/aarch64/bin/_core
+++ b/compileiq/core/executable/linux/aarch64/bin/_core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a3e32c027b397b8c7e68b6d39bdd01d1877e0ed11008dab6444334277100007c
-size 92409552
+oid sha256:7000aebea4b608457d2b0896fb5ee3cd6abd067f2374f2e9f9fe2e7b95fc5e61
+size 92410112

--- a/compileiq/core/executable/linux/aarch64/bin/core
+++ b/compileiq/core/executable/linux/aarch64/bin/core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8
-size 165
+oid sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882
+size 224

--- a/compileiq/core/executable/linux/x86_64/bin/_core
+++ b/compileiq/core/executable/linux/x86_64/bin/_core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0fea2a15f0935c2c0c511822d3772a27a4695b3b7912aa089051ef9dea527d4c
-size 90187664
+oid sha256:32f510aa8600c6c001a2da516aa0023b26b5326b71f6ee3dbb8b3406af20d18e
+size 90188000

--- a/compileiq/core/executable/linux/x86_64/bin/core
+++ b/compileiq/core/executable/linux/x86_64/bin/core
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:416bbe063a7584bb4d70c62983421e7439658689fd1e7da501453ceada4a5bb8
-size 165
+oid sha256:9fa6463d7210b96d61bc6c1e3a2f7484f2b9b44c5a30a63840c6cd4365baf882
+size 224

--- a/compileiq/core/executable/win32/amd64/core.exe
+++ b/compileiq/core/executable/win32/amd64/core.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b4f1a63193d2cad5787ed515f57d20ff0b62e52d687e9bb989d7f26d7ce7c53
+oid sha256:aa32eeb9457fb52e524035061e0f5c234f38b9199b846180fb41e29244ac8cd7
 size 70336000

--- a/compileiq/search_spaces/base.py
+++ b/compileiq/search_spaces/base.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import Any, Optional, Annotated, Sequence
 from annotated_types import Gt
 import numpy as np
@@ -7,6 +8,13 @@ from compileiq.search_spaces.models import (
     ChoiceParamConfig,
     LiteralParamConfig,
 )
+
+
+def _probability_to_threshold(knockout_prob: Optional[float]) -> Optional[float]:
+    """Convert omission probability without introducing a binary-float artifact."""
+    if knockout_prob is None:
+        return None
+    return float(Decimal("1") - Decimal(str(knockout_prob)))
 
 
 def range(
@@ -62,7 +70,7 @@ def range(
     if end <= start:
         raise ValueError("Please provide a proper range value where start < end.")
 
-    knockout_threshold = (1.0 - knockout_prob) if knockout_prob is not None else None
+    knockout_threshold = _probability_to_threshold(knockout_prob)
 
     # Validating seeding option
     if seed_low is not None and seed_high is not None:
@@ -113,7 +121,7 @@ def choice(
         else:
             processed.append(val)
 
-    knockout_threshold = (1.0 - knockout_prob) if knockout_prob is not None else None
+    knockout_threshold = _probability_to_threshold(knockout_prob)
 
     return ChoiceParamConfig(
         vals=processed,
@@ -147,7 +155,7 @@ def literal(
     if isinstance(const_value, bool):
         const_value = int(const_value)
 
-    knockout_threshold = (1.0 - knockout_prob) if knockout_prob is not None else None
+    knockout_threshold = _probability_to_threshold(knockout_prob)
 
     return LiteralParamConfig(
         value=const_value,

--- a/dev/smoke_test_encrypted_search_space.py
+++ b/dev/smoke_test_encrypted_search_space.py
@@ -20,6 +20,17 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
+def _sha256_value(value: str) -> str:
+    normalized = value.removeprefix("sha256:").lower()
+    if len(normalized) != 64:
+        raise argparse.ArgumentTypeError("must be a 64-character SHA-256 digest")
+    try:
+        bytes.fromhex(normalized)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("must be a hexadecimal SHA-256 digest") from error
+    return normalized
+
+
 def _decode_candidate(candidate: object, index: int) -> bytes:
     if not isinstance(candidate, str) or not candidate:
         raise RuntimeError(f"candidate {index} is not a non-empty encrypted hex string")
@@ -133,21 +144,33 @@ def main() -> None:
     parser.add_argument("--pool-size", type=_positive_int, default=6)
     parser.add_argument("--cull-size", type=_positive_int, default=2)
     parser.add_argument("--workers", type=_positive_int, default=1)
+    parser.add_argument("--expected-sha256", type=_sha256_value)
+    parser.add_argument("--expected-size", type=_positive_int)
     args = parser.parse_args()
 
     if not args.search_space.is_file():
         parser.error(f"search-space file does not exist: {args.search_space}")
     if args.cull_size >= args.pool_size:
         parser.error("--cull-size must be smaller than --pool-size")
+    artifact = args.search_space.read_bytes()
+    artifact_sha256 = _sha256(artifact)
+    if args.expected_sha256 is not None and artifact_sha256 != args.expected_sha256:
+        parser.error(
+            f"search-space SHA-256 mismatch: expected {args.expected_sha256}, "
+            f"got {artifact_sha256}"
+        )
+    if args.expected_size is not None and len(artifact) != args.expected_size:
+        parser.error(
+            f"search-space size mismatch: expected {args.expected_size}, got {len(artifact)}"
+        )
     if args.output_dir.exists() and any(args.output_dir.iterdir()):
         parser.error(f"output directory must be empty: {args.output_dir}")
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    artifact = args.search_space.read_bytes()
     manifest: dict[str, Any] = {
         "artifact": {
             "filename": args.search_space.name,
-            "sha256": _sha256(artifact),
+            "sha256": artifact_sha256,
             "size_bytes": len(artifact),
         },
         "mode": args.mode,

--- a/dev/validate_encrypted_search_space.py
+++ b/dev/validate_encrypted_search_space.py
@@ -1,0 +1,179 @@
+"""Smoke-test an encrypted search-space artifact through the public CompileIQ API."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from compileiq.ciq import Search
+from compileiq.types import SearchConfiguration
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _decode_candidate(candidate: object, index: int) -> bytes:
+    if not isinstance(candidate, str) or not candidate:
+        raise RuntimeError(f"candidate {index} is not a non-empty encrypted hex string")
+
+    try:
+        decoded = bytes.fromhex(candidate)
+    except ValueError as error:
+        raise RuntimeError(f"candidate {index} is not valid hexadecimal") from error
+
+    if not decoded:
+        raise RuntimeError(f"candidate {index} decodes to an empty payload")
+    return decoded
+
+
+def _smoke_objective(candidate: object) -> float:
+    """Return a deterministic score while validating the protected candidate boundary."""
+    return float(len(_decode_candidate(candidate, 0)))
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write_candidates(candidates: Sequence[object], output_dir: Path) -> list[dict[str, Any]]:
+    output_dir.mkdir(parents=True)
+    manifest: list[dict[str, Any]] = []
+    for index, candidate in enumerate(candidates):
+        payload = _decode_candidate(candidate, index)
+        filename = f"candidate-{index:03d}.bin"
+        (output_dir / filename).write_bytes(payload)
+        manifest.append(
+            {
+                "filename": filename,
+                "sha256": _sha256(payload),
+                "size_bytes": len(payload),
+            }
+        )
+    return manifest
+
+
+def _new_search(search_space: Path, cache_dir: Path, pool_size: int, cull_size: int) -> Search:
+    return Search(
+        objective_function=_smoke_objective,
+        search_space=search_space,
+        search_config=SearchConfiguration(
+            generations=1,
+            pool_size=pool_size,
+            cull_size=cull_size,
+            problem_type="min",
+            num_objectives=1,
+        ),
+        cache_folder=cache_dir,
+        disable_progress_bar=True,
+    )
+
+
+def _run_sample(
+    search_space: Path,
+    output_dir: Path,
+    sample_count: int,
+    pool_size: int,
+    cull_size: int,
+) -> dict[str, Any]:
+    search = _new_search(search_space, output_dir / "cache", pool_size, cull_size)
+    candidates = search.sample(num_samples=sample_count)
+    if len(candidates) != sample_count:
+        raise RuntimeError(
+            f"sample() returned {len(candidates)} candidates; expected {sample_count}"
+        )
+    return {
+        "candidate_count": len(candidates),
+        "candidates": _write_candidates(candidates, output_dir / "candidates"),
+    }
+
+
+def _run_search(
+    search_space: Path,
+    output_dir: Path,
+    pool_size: int,
+    cull_size: int,
+    workers: int,
+) -> dict[str, Any]:
+    search = _new_search(search_space, output_dir / "cache", pool_size, cull_size)
+    results = search.start(num_workers=workers).get_results()
+    required_columns = {"score_1", "params", "generation"}
+    missing_columns = sorted(required_columns.difference(results.columns))
+    if missing_columns:
+        raise RuntimeError(f"search results are missing columns: {', '.join(missing_columns)}")
+    if results.empty:
+        raise RuntimeError("search returned no results")
+    if len(results) > pool_size:
+        raise RuntimeError(
+            f"search returned {len(results)} rows; expected no more than {pool_size}"
+        )
+
+    candidates = results["params"].tolist()
+    return {
+        "candidate_count": len(candidates),
+        "candidates": _write_candidates(candidates, output_dir / "candidates"),
+        "result_columns": sorted(results.columns.tolist()),
+        "result_rows": len(results),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--search-space", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--mode", choices=("sample", "search", "both"), default="both")
+    parser.add_argument("--samples", type=_positive_int, default=8)
+    parser.add_argument("--pool-size", type=_positive_int, default=6)
+    parser.add_argument("--cull-size", type=_positive_int, default=2)
+    parser.add_argument("--workers", type=_positive_int, default=1)
+    args = parser.parse_args()
+
+    if not args.search_space.is_file():
+        parser.error(f"search-space file does not exist: {args.search_space}")
+    if args.cull_size >= args.pool_size:
+        parser.error("--cull-size must be smaller than --pool-size")
+    if args.output_dir.exists() and any(args.output_dir.iterdir()):
+        parser.error(f"output directory must be empty: {args.output_dir}")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    artifact = args.search_space.read_bytes()
+    manifest: dict[str, Any] = {
+        "artifact": {
+            "filename": args.search_space.name,
+            "sha256": _sha256(artifact),
+            "size_bytes": len(artifact),
+        },
+        "mode": args.mode,
+        "schema_version": 1,
+    }
+    if args.mode in {"sample", "both"}:
+        manifest["sample"] = _run_sample(
+            args.search_space,
+            args.output_dir / "sample",
+            args.samples,
+            max(args.pool_size, args.samples),
+            args.cull_size,
+        )
+    if args.mode in {"search", "both"}:
+        manifest["search"] = _run_search(
+            args.search_space,
+            args.output_dir / "search",
+            args.pool_size,
+            args.cull_size,
+            args.workers,
+        )
+
+    manifest_path = args.output_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(manifest, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/search_spaces/test_base.py
+++ b/tests/unit/search_spaces/test_base.py
@@ -3,6 +3,7 @@ Tests for search space builders in compileiq/search_spaces/base.py.
 """
 
 import json
+import math
 import pytest
 from compileiq.search_spaces import base as ss
 from compileiq.search_spaces.models import (
@@ -51,6 +52,26 @@ def test_knockout_threshold_is_inverted():
     # threshold = 1.0 - knockout_prob
     result = ss.literal(const_value=1, knockout_prob=0.3)
     assert result.knockout_threshold == pytest.approx(0.7)
+
+
+@pytest.mark.parametrize(
+    "fn,kwargs",
+    [
+        (ss.range, {"start": 0, "end": 10}),
+        (ss.choice, {"choice_list": [1, 2, 3]}),
+        (ss.literal, {"const_value": 5}),
+        (ss.log_sampling, {"start": 0.001, "end": 1.0}),
+    ],
+)
+def test_knockout_prob_point_seven_has_exact_quantized_contract(fn, kwargs):
+    result = fn(**kwargs, knockout_prob=0.7)
+
+    assert result.knockout_threshold == 0.3
+    assert '"knockout_threshold":0.3' in result.model_dump_json()
+
+    cutoff = math.ceil(100 * result.knockout_threshold)
+    assert cutoff == 30
+    assert sum(genotype >= cutoff for genotype in range(100)) == 70
 
 
 def test_literal_dive_threads_knockout():

--- a/tests/unit/test_encrypted_search_space_smoke.py
+++ b/tests/unit/test_encrypted_search_space_smoke.py
@@ -1,0 +1,19 @@
+import argparse
+
+import pytest
+
+from dev.smoke_test_encrypted_search_space import _sha256_value
+
+
+SHA256 = "9a232adcc36a6451a4a30f3fe1dbfb29c4476b7b324bcec87bc0f5cc30bbf70d"
+
+
+@pytest.mark.parametrize("value", [SHA256, f"sha256:{SHA256}", SHA256.upper()])
+def test_sha256_value_accepts_release_digest_forms(value):
+    assert _sha256_value(value) == SHA256
+
+
+@pytest.mark.parametrize("value", ["short", "g" * 64])
+def test_sha256_value_rejects_invalid_digest(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        _sha256_value(value)

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -92,6 +92,23 @@ def test_ci_workflow_no_longer_deploys_pages_artifacts():
 
     assert "deploy-pages:" not in content
     assert "actions/deploy-pages" not in content
+
+
+def test_release_wheel_matrix_smokes_pinned_encrypted_search_space():
+    content = CI_WORKFLOW.read_text()
+    smoke_step = content.split(
+        "- name: Smoke encrypted search space through installed wheel", 1
+    )[1].split("- name: Upload smoke-tested wheel artifact", 1)[0]
+
+    assert "dev/smoke_test_encrypted_search_space.py" in smoke_step
+    assert "search-spaces-2026.08.14/ptxas13.4_search_space.bin" in smoke_step
+    assert (
+        "--expected-sha256 "
+        "9a232adcc36a6451a4a30f3fe1dbfb29c4476b7b324bcec87bc0f5cc30bbf70d"
+        in smoke_step
+    )
+    assert "--expected-size 13904" in smoke_step
+    assert "--mode both" in smoke_step
     assert "actions/upload-pages-artifact" not in content
 
 

--- a/tests/unit/test_release_workflow.py
+++ b/tests/unit/test_release_workflow.py
@@ -11,6 +11,10 @@ CI_WORKFLOW = WORKFLOWS / "ci.yml"
 DOCS_WORKFLOW = WORKFLOWS / "docs.yml"
 
 
+def _make_target_block(content: str, target: str, next_target: str) -> str:
+    return content.split(f"{target}:", 1)[1].split(f"\n{next_target}:", 1)[0]
+
+
 def test_search_space_release_workflow_is_not_active_without_artifact_staging():
     content = CI_WORKFLOW.read_text()
     legacy_assets_glob = "/".join(("assets", "*.bin"))
@@ -54,6 +58,33 @@ def test_search_space_release_prep_is_local_until_publish_path_is_decided():
     content = CI_WORKFLOW.read_text()
 
     assert "startsWith(github.ref, 'refs/tags/search-spaces-')" not in content
+
+
+def test_catalog_releases_publish_atomically_without_becoming_latest():
+    content = MAKEFILE.read_text()
+    release_targets = (
+        (
+            "publish-search-space-release",
+            "clear-search-space-latest",
+            "check-search-space-published",
+        ),
+        (
+            "publish-booster-pack-release",
+            "clear-booster-pack-latest",
+            "check-booster-pack-published",
+        ),
+    )
+
+    for publish_target, next_target, check_target in release_targets:
+        recipe = _make_target_block(content, publish_target, next_target)
+
+        assert "set -eu" in recipe
+        assert recipe.count("gh api --method PATCH") == 1
+        assert "-F draft=false" in recipe
+        assert "-f make_latest=false" in recipe
+        assert recipe.index("-F draft=false") < recipe.index("-f make_latest=false")
+        assert f"$(MAKE) --no-print-directory {check_target}" in recipe
+        assert recipe.index(check_target) < recipe.index('echo "PASS: Published')
 
 
 def test_ci_workflow_no_longer_deploys_pages_artifacts():


### PR DESCRIPTION
## Summary

- Preserve exact knockout-probability quantization in public search-space builders.
- Bundle the corrected core while retaining compatibility with legacy threshold-based search spaces.
- Add a SHA- and size-pinned encrypted search-space smoke test through installed wheels.
- Run the wheel smoke on Linux x86_64 for pull requests and on Linux x86_64, Linux arm64, and
  Windows for `main` and version tags.
- Publish catalog releases atomically without allowing catalog releases to become GitHub's Latest
  package release.

## Motivation

Search spaces that use omission probabilities need to retain those semantics across serialization,
encryption, packaging, and execution. This change fixes the conversion boundary, bundles the core
that understands the canonical field, and adds an installed-wheel test that exercises the real
encrypted artifact path before a package release can be published.

## Validation

- 59 focused unit and release-workflow tests passed locally.
- Ruff passed for the changed Python and test files.
- Pyright reported zero errors for the changed implementation files.
- Bundled-core verification checked all eight platform files and the manifest successfully.
- `git diff --check` and Git LFS integrity checks passed.

## Release impact

This is a backward-compatible bug fix intended for CompileIQ v1.0.3. No public API changes are
introduced.
