### PR TITLE
Update Booster Pack metadata and release validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,7 @@ check-booster-pack-staging: ## Validate local staged Booster Pack release before
 		--tag "$(BOOSTER_RELEASE_TAG)" \
 		--extra-ok release-body.md \
 		--docs-url "$(BOOSTER_DOCS_URL)" \
+		--require-validation-passed \
 		--require-release-body
 
 # Validate assets downloaded from GitHub. release-body.md is not uploaded as an
@@ -389,7 +390,8 @@ check-booster-pack-assets: ## Validate Booster Pack assets downloaded from GitHu
 		"$(BOOSTER_OUTPUT_DIR)" \
 		--tag "$(BOOSTER_RELEASE_TAG)" \
 		--extra-ok release-body.md \
-		--docs-url "$(BOOSTER_DOCS_URL)"
+		--docs-url "$(BOOSTER_DOCS_URL)" \
+		--require-validation-passed
 
 # Show draft release metadata for a final read-only human sanity check.
 inspect-booster-pack-release: ## Inspect draft Booster Pack release before publishing

--- a/agent-skills/compileiq-author-objective/SKILL.md
+++ b/agent-skills/compileiq-author-objective/SKILL.md
@@ -153,8 +153,8 @@ assert isinstance(score, (int, float)) and score == score   # not NaN
 
 # ACF-injection canary using the Debug pack (downloaded once)
 from compileiq.utils.helpers import load_compiler_config
-O0_HEX = load_compiler_config("debug-pack/O0.acf")
-O3_HEX = load_compiler_config("debug-pack/O3.acf")
+O0_HEX = load_compiler_config("booster-pack-debug/ptxas_opt0.acf")
+O3_HEX = load_compiler_config("booster-pack-debug/ptxas_opt3.acf")
 
 baseline = objective({})                  # BASELINE_CONFIG path
 score_O0 = objective(O0_HEX)

--- a/agent-skills/compileiq-booster-pack/SKILL.md
+++ b/agent-skills/compileiq-booster-pack/SKILL.md
@@ -52,8 +52,9 @@ Authoritative narrative: `docs/booster_packs.md`, `docs/flashinfer_booster.md`.
 | `booster-pack-helion.zip` | Helion FP8 Quantization, Causal Depthwise Convolution, Gated DeltaNet Forward | Has shown benefit on FlashInfer `BatchDecodeWithPagedKVCacheWrapper`; related attention workloads worth testing. |
 | `booster-pack-debug.zip` | Diagnostic ACFs (`O0`, `O3`, others that disable or alter selected optimizations) | Not for speed; for **debugging**. Use the O0/O3 canary below before trusting any other pack. |
 
-The public release shape is documented in `docs/booster_packs.md`. There is no
-runtime download API today. Don't invent one.
+The public release shape is documented in `docs/booster_packs.md`. Read each
+candidate's `compiler_stages` from its pack manifest and use every listed stage.
+There is no runtime download API today. Don't invent one.
 
 ## Steps
 
@@ -64,9 +65,9 @@ Helion, FlashInfer's `flashinfer_cubin`/`flashinfer_jit_cache`, NVCC build
 cache) serving a stale binary that ignored the ACF. The Debug pack has two
 ACFs with predictable, opposite-direction signatures:
 
-- **`O0` ACF**: forces unoptimized compilation. Applied → expect a **measurable
+- **`ptxas_opt0.acf`**: forces unoptimized PTXAS compilation. Applied → expect a **measurable
   regression** (often 2-10x slower) vs. baseline.
-- **`O3` ACF**: forces the default optimization level. Applied → expect to
+- **`ptxas_opt3.acf`**: forces the default PTXAS optimization level. Applied → expect to
   **match baseline** (the no-ACF default is already `-O3`).
 
 ```bash
@@ -74,10 +75,10 @@ ACFs with predictable, opposite-direction signatures:
 T_BASE_MS=$(./run-benchmark.sh)
 
 # O0 must regress
-PTXAS_OPTIONS="--apply-controls=debug-pack/O0.acf" T_O0_MS=$(./run-benchmark.sh)
+PTXAS_OPTIONS="--apply-controls=booster-pack-debug/ptxas_opt0.acf" T_O0_MS=$(./run-benchmark.sh)
 
 # O3 must match baseline
-PTXAS_OPTIONS="--apply-controls=debug-pack/O3.acf" T_O3_MS=$(./run-benchmark.sh)
+PTXAS_OPTIONS="--apply-controls=booster-pack-debug/ptxas_opt3.acf" T_O3_MS=$(./run-benchmark.sh)
 
 python -c "
 import sys

--- a/dev/build_booster_pack_release.py
+++ b/dev/build_booster_pack_release.py
@@ -35,7 +35,7 @@ def sha256_file(path: pathlib.Path) -> str:
 
 
 def json_bytes(value: object) -> bytes:
-    return (json.dumps(value, indent=2) + "\n").encode("utf-8")
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
 
 
 def _mapping(value: object, context: str) -> dict[str, object]:
@@ -84,13 +84,14 @@ def _compact_acf_entries(manifest: Mapping[str, object]) -> list[dict[str, objec
     result: list[dict[str, object]] = []
     for index, entry in enumerate(_list(manifest.get("acfs"), "manifest acfs")):
         acf = _mapping(entry, f"manifest acfs[{index}]")
-        result.append(
-            {
-                "filename": acf.get("filename"),
-                "sha256": acf.get("sha256"),
-                "size_bytes": acf.get("size_bytes"),
-            }
-        )
+        compact = {
+            "filename": acf.get("filename"),
+            "sha256": acf.get("sha256"),
+            "size_bytes": acf.get("size_bytes"),
+        }
+        if "compiler_stages" in acf:
+            compact["compiler_stages"] = acf["compiler_stages"]
+        result.append(compact)
     return result
 
 

--- a/dev/verify_booster_pack_release.py
+++ b/dev/verify_booster_pack_release.py
@@ -16,6 +16,7 @@ from collections.abc import Iterable
 HEX_SHA256 = re.compile(r"^[0-9a-f]{64}$")
 FIXME_RE = re.compile(r"\bFIXME\b", re.IGNORECASE)
 DEFAULT_DOCS_URL = "https://nvidia.github.io/CompileIQ/stable/booster_packs.html"
+ALLOWED_COMPILER_STAGES = {"nvcc", "ptxas"}
 
 
 def sha256_bytes(payload: bytes) -> str:
@@ -131,7 +132,62 @@ def _entry_map(
         if not isinstance(size, int) or size <= 0:
             errors.append(f"{entry_context}: invalid size_bytes for {filename}")
 
+        compiler_stages = entry_obj.get("compiler_stages")
+        if compiler_stages is not None:
+            if not isinstance(compiler_stages, list) or not compiler_stages:
+                errors.append(f"{entry_context}: compiler_stages must be a non-empty list")
+            elif (
+                not all(stage in ALLOWED_COMPILER_STAGES for stage in compiler_stages)
+                or compiler_stages != sorted(set(compiler_stages))
+            ):
+                errors.append(
+                    f"{entry_context}: compiler_stages must be sorted, unique, and use "
+                    "only nvcc or ptxas"
+                )
+
     return result
+
+
+def _validate_stage_metadata(
+    pack_id: str,
+    controls_stage: object,
+    entries: dict[str, dict[str, object]],
+    errors: list[str],
+) -> None:
+    if controls_stage is None:
+        errors.append(f"{pack_id}: missing controls_stage")
+        return
+    if controls_stage not in {"nvcc", "ptxas", "both"}:
+        errors.append(f"{pack_id}: invalid controls_stage {controls_stage!r}")
+        return
+
+    if controls_stage == "both":
+        missing = sorted(
+            filename for filename, entry in entries.items() if "compiler_stages" not in entry
+        )
+        if missing:
+            errors.append(
+                f"{pack_id}: controls_stage 'both' requires compiler_stages for every ACF: "
+                f"{missing}"
+            )
+            return
+        stage_union = {
+            stage
+            for entry in entries.values()
+            for stage in entry.get("compiler_stages", [])
+            if isinstance(stage, str)
+        }
+        if stage_union != ALLOWED_COMPILER_STAGES:
+            errors.append(f"{pack_id}: controls_stage 'both' must cover nvcc and ptxas ACFs")
+        return
+
+    for filename, entry in entries.items():
+        compiler_stages = entry.get("compiler_stages")
+        if compiler_stages is not None and compiler_stages != [controls_stage]:
+            errors.append(
+                f"{pack_id}: {filename} compiler_stages must match controls_stage "
+                f"{controls_stage!r}"
+            )
 
 
 def _validate_checksum_file(
@@ -180,6 +236,7 @@ def _validate_pack(
     catalog_version: object,
     pack: dict[str, object],
     checksums: dict[str, str],
+    require_validation_passed: bool,
     errors: list[str],
 ) -> None:
     pack_id = pack.get("pack_id")
@@ -258,6 +315,19 @@ def _validate_pack(
             if manifest_obj.get("pack_id") != pack_id:
                 errors.append(f"{pack_id}: manifest pack_id is {manifest_obj.get('pack_id')!r}")
 
+            catalog_validation = pack.get("validation_summary")
+            manifest_validation = manifest_obj.get("validation_summary")
+            if catalog_validation != manifest_validation:
+                errors.append(f"{pack_id}: catalog and manifest validation_summary differ")
+            if require_validation_passed:
+                if not isinstance(manifest_validation, dict):
+                    errors.append(f"{pack_id}: manifest validation_summary must be an object")
+                elif manifest_validation.get("status") != "passed":
+                    errors.append(
+                        f"{pack_id}: validation status must be 'passed', got "
+                        f"{manifest_validation.get('status')!r}"
+                    )
+
             catalog_acfs = _entry_map(pack.get("acfs"), f"{pack_id}: catalog acfs", errors)
             manifest_acfs = _entry_map(
                 manifest_obj.get("acfs"),
@@ -269,6 +339,24 @@ def _validate_pack(
                     f"{pack_id}: catalog and manifest ACF filenames differ: "
                     f"catalog={sorted(catalog_acfs)}, manifest={sorted(manifest_acfs)}"
                 )
+
+            for filename in sorted(set(catalog_acfs) & set(manifest_acfs)):
+                if catalog_acfs[filename].get("compiler_stages") != manifest_acfs[filename].get(
+                    "compiler_stages"
+                ):
+                    errors.append(
+                        f"{pack_id}: catalog and manifest compiler_stages differ for {filename}"
+                    )
+
+            catalog_controls_stage = pack.get("controls_stage")
+            manifest_controls_stage = manifest_obj.get("controls_stage")
+            if catalog_controls_stage != manifest_controls_stage:
+                errors.append(
+                    f"{pack_id}: catalog controls_stage {catalog_controls_stage!r} differs "
+                    f"from manifest {manifest_controls_stage!r}"
+                )
+            _validate_stage_metadata(pack_id, catalog_controls_stage, catalog_acfs, errors)
+            _validate_stage_metadata(pack_id, manifest_controls_stage, manifest_acfs, errors)
 
             acf_count = pack.get("acf_count")
             if isinstance(acf_count, int) and manifest_acfs and acf_count != len(manifest_acfs):
@@ -348,6 +436,7 @@ def validate_release_assets(
     extra_ok: Iterable[str] = (),
     docs_url: str = DEFAULT_DOCS_URL,
     require_release_body: bool = False,
+    require_validation_passed: bool = False,
 ) -> list[str]:
     """Return validation errors for a Booster Pack release asset directory."""
     errors: list[str] = []
@@ -399,7 +488,15 @@ def validate_release_assets(
                 errors.append(f"duplicate artifact_name {artifact_name}")
             seen_artifacts.add(artifact_name)
 
-        _validate_pack(asset_dir, tag, catalog_version, pack_obj, checksums, errors)
+        _validate_pack(
+            asset_dir,
+            tag,
+            catalog_version,
+            pack_obj,
+            checksums,
+            require_validation_passed,
+            errors,
+        )
 
     _validate_release_body(asset_dir, catalog_obj, docs_url, require_release_body, errors)
 
@@ -436,6 +533,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Require release-body.md and validate its public docs URL and asset names.",
     )
+    parser.add_argument(
+        "--require-validation-passed",
+        action="store_true",
+        help="Require every pack manifest validation_summary.status to be passed.",
+    )
     args = parser.parse_args(argv)
 
     errors = validate_release_assets(
@@ -444,6 +546,7 @@ def main(argv: list[str] | None = None) -> int:
         args.extra_ok,
         args.docs_url,
         args.require_release_body,
+        args.require_validation_passed,
     )
     if errors:
         print(f"FAIL: Booster Pack release validation failed for {args.tag}.", file=sys.stderr)

--- a/docs/booster_packs.md
+++ b/docs/booster_packs.md
@@ -49,7 +49,7 @@ Each catalog release includes:
 * `SHA256SUMS.txt`, which records checksums for the uploaded catalog and pack zip assets.
 * `booster-pack-debug.zip`, the diagnostic Debug Pack.
 * `booster-pack-helion.zip`, the Helion Booster Pack.
-* Each Booster Pack zip consists of ACFs and a pack-specific `booster-pack-manifest.json` that describes the ACFs for that pack.
+* Each Booster Pack zip consists of ACFs and a pack-specific `booster-pack-manifest.json` that describes the ACFs for that pack. When a pack covers more than one compiler stage, each ACF entry includes `compiler_stages` so you can choose the correct NVCC/NVVM, PTXAS, or combined application path.
 
 The release notes, catalog file, and pack manifest are the source of truth for each pack; check them for the intended workload, compiler version and path or compiler stage, GPU target, validation context, and known caveats.
 
@@ -59,19 +59,21 @@ The basic workflow is:
 
 1. Run your workload without an ACF and save the baseline result.
 2. Download the Booster Pack from the filtered GitHub Releases page.
-3. Unzip the pack.
-4. Apply one ACF at a time through the Controls Interface.
+3. Unzip the pack and inspect each ACF's `compiler_stages` in `booster-pack-manifest.json`.
+4. Apply one ACF at a time through every compiler stage listed for that ACF.
 5. Validate correctness against a known-good reference.
 6. Compare performance against the no-ACF baseline.
 7. Keep only candidates that compile, pass correctness, and improve the target workload.
 
-For direct PTXAS usage, pass the ACF with `--apply-controls`:
+For direct PTXAS usage, select an ACF whose `compiler_stages` includes `ptxas` and
+pass it with `--apply-controls`:
 
 ```bash
 ptxas -v -arch=sm_90a --apply-controls candidate.acf kernel.ptx
 ```
 
-For NVCC usage, pass the same option to NVCC:
+For NVCC usage, select an ACF whose `compiler_stages` includes `nvcc` and pass the
+same option to NVCC:
 
 ```bash
 nvcc -arch=sm_100 --apply-controls candidate.acf kernel.cu -o kernel

--- a/tests/unit/test_booster_release_builder.py
+++ b/tests/unit/test_booster_release_builder.py
@@ -56,6 +56,7 @@ def _write_pack_zip(
                 "filename": "candidate.acf",
                 "sha256": builder.sha256_bytes(payload),
                 "size_bytes": len(payload),
+                "compiler_stages": ["ptxas"],
             }
         ],
     }
@@ -121,6 +122,7 @@ def test_build_release_generates_valid_stable_docs_bundle(tmp_path):
     assert catalog["generated_at"] == "2026-05-21T00:00:00Z"
     assert catalog["packs"][0]["artifact_name"] == "booster-pack-debug.zip"
     assert catalog["packs"][0]["acf_count"] == 1
+    assert catalog["packs"][0]["acfs"][0]["compiler_stages"] == ["ptxas"]
 
     release_body = (output_dir / "release-body.md").read_text()
     assert "## Booster Pack Catalog Release" in release_body

--- a/tests/unit/test_booster_release_verifier.py
+++ b/tests/unit/test_booster_release_verifier.py
@@ -25,12 +25,21 @@ def _json_bytes(value: object) -> bytes:
     return (json.dumps(value, indent=2) + "\n").encode("utf-8")
 
 
-def _write_valid_release(asset_dir: pathlib.Path, tag: str) -> None:
+def _write_valid_release(
+    asset_dir: pathlib.Path,
+    tag: str,
+    *,
+    compiler_stages: list[str] | None = None,
+    controls_stage: str = "ptxas",
+    validation_status: str = "passed",
+) -> None:
+    compiler_stages = compiler_stages or ["ptxas"]
     acf_payload = b"controls"
     acf = {
         "filename": "candidate.acf",
         "sha256": verifier.sha256_bytes(acf_payload),
         "size_bytes": len(acf_payload),
+        "compiler_stages": compiler_stages,
     }
     manifest = {
         "schema_version": 1,
@@ -39,6 +48,12 @@ def _write_valid_release(asset_dir: pathlib.Path, tag: str) -> None:
         "pack_id": "debug-pack",
         "pack_type": "diagnostic",
         "display_name": "Debug Pack",
+        "controls_stage": controls_stage,
+        "validation_summary": {
+            "status": validation_status,
+            "evidence": "Exact candidate validation passed",
+            "notes": ["Validated before release packaging"],
+        },
         "acfs": [acf],
     }
     manifest_payload = _json_bytes(manifest)
@@ -57,6 +72,8 @@ def _write_valid_release(asset_dir: pathlib.Path, tag: str) -> None:
                 "pack_id": "debug-pack",
                 "pack_type": "diagnostic",
                 "display_name": "Debug Pack",
+                "controls_stage": controls_stage,
+                "validation_summary": manifest["validation_summary"],
                 "acf_count": 1,
                 "acfs": [acf],
                 "artifact_name": zip_path.name,
@@ -82,6 +99,72 @@ def test_validate_release_assets_accepts_valid_bundle(tmp_path):
     _write_valid_release(tmp_path, tag)
 
     assert verifier.validate_release_assets(tmp_path, tag) == []
+
+
+def test_stage_metadata_requires_explicit_map_for_mixed_pack():
+    errors: list[str] = []
+    verifier._validate_stage_metadata(
+        "debug-pack",
+        "both",
+        {
+            "nvvm.acf": {"filename": "nvvm.acf"},
+            "ptxas.acf": {"filename": "ptxas.acf", "compiler_stages": ["ptxas"]},
+        },
+        errors,
+    )
+    assert errors == [
+        "debug-pack: controls_stage 'both' requires compiler_stages for every ACF: "
+        "['nvvm.acf']"
+    ]
+
+
+def test_stage_metadata_accepts_nvcc_ptxas_and_combined_entries():
+    errors: list[str] = []
+    verifier._validate_stage_metadata(
+        "debug-pack",
+        "both",
+        {
+            "nvvm.acf": {"compiler_stages": ["nvcc"]},
+            "nvvm_ptxas.acf": {"compiler_stages": ["nvcc", "ptxas"]},
+            "ptxas.acf": {"compiler_stages": ["ptxas"]},
+        },
+        errors,
+    )
+    assert errors == []
+
+
+def test_validate_release_assets_rejects_catalog_manifest_stage_mismatch(tmp_path):
+    tag = "booster-packs-2026.05.21"
+    _write_valid_release(tmp_path, tag)
+    catalog_path = tmp_path / "booster-pack-catalog.json"
+    catalog = json.loads(catalog_path.read_text())
+    catalog["packs"][0]["controls_stage"] = "nvcc"
+    catalog_path.write_bytes(_json_bytes(catalog))
+    zip_path = tmp_path / "booster-pack-debug.zip"
+    (tmp_path / "SHA256SUMS.txt").write_text(
+        f"{verifier.sha256_file(catalog_path)}  {catalog_path.name}\n"
+        f"{verifier.sha256_file(zip_path)}  {zip_path.name}\n"
+    )
+
+    errors = verifier.validate_release_assets(tmp_path, tag)
+
+    assert (
+        "debug-pack: catalog controls_stage 'nvcc' differs from manifest 'ptxas'"
+    ) in errors
+
+
+def test_validate_release_assets_final_gate_rejects_pending_validation(tmp_path):
+    tag = "booster-packs-2026.05.21"
+    _write_valid_release(tmp_path, tag, validation_status="pending")
+
+    assert verifier.validate_release_assets(tmp_path, tag) == []
+    errors = verifier.validate_release_assets(
+        tmp_path,
+        tag,
+        require_validation_passed=True,
+    )
+
+    assert "debug-pack: validation status must be 'passed', got 'pending'" in errors
 
 
 def test_main_prints_pass_on_valid_bundle(tmp_path, capsys):


### PR DESCRIPTION
## Description

This change makes compiler-stage metadata explicit for each ACF in mixed-stage
Booster Packs and preserves that metadata in the generated catalog. It also
tightens release verification so catalog and manifest stage metadata must agree,
and final staging or downloaded-asset checks require a declared validation status
of `passed`.

The public Booster Pack documentation and agent guidance now explain how to select
the correct NVCC/NVVM, PTXAS, or combined application path and use the current
Debug Pack filenames.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/CompileIQ/blob/main/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

- `poetry run pytest -p no:cacheprovider tests/unit/test_booster_release_builder.py tests/unit/test_booster_release_verifier.py -q` (`15 passed`)
- `poetry run ruff check --no-cache dev/build_booster_pack_release.py dev/verify_booster_pack_release.py tests/unit/test_booster_release_builder.py tests/unit/test_booster_release_verifier.py` (`All checks passed`)
- `git diff --check origin/main...HEAD`
- The prepared catalog bundle passed structural and required-status verification.
- Manual public-surface review found no private URLs, internal repository or branch names, local paths, customer or partner details, or secret-like values in the added content.

## Risk and follow-up

The change is limited to release tooling, validation, documentation, and agent
guidance; it does not alter runtime search behavior. Invalid stage metadata is
rejected before release staging or downloaded-asset acceptance.

One nonblocking diagnostic edge remains: a non-string, unhashable item inside
`compiler_stages` fails closed with a nonzero exit but produces a Python traceback
instead of a formatted validation error. A focused follow-up can make that error
path consistent with the verifier's other malformed-input diagnostics.

## New feature / enhancement

Mixed-stage manifests can describe the application path per ACF:

```json
{
  "controls_stage": "both",
  "acfs": [
    {
      "filename": "candidate.acf",
      "compiler_stages": ["nvcc", "ptxas"]
    }
  ]
}
```

Final staging validation requires every pack to declare a passed status:

```bash
make check-booster-pack-staging \
  BOOSTER_RELEASE_TAG=booster-packs-YYYY.MM.DD \
  BOOSTER_OUTPUT_DIR=/path/to/staged-assets
```
