### PR TITLE
Swapped the docs and examples column in compiler_overview.md

### DIFF
--- a/docs/compilers_overview.md
+++ b/docs/compilers_overview.md
@@ -89,12 +89,12 @@ When selecting a successful sample from the search, test it in the target deploy
 
 Each example below follows this pattern: define an objective function, define or fetch a search space, and run a CompileIQ search.
 
-| Example | Compiler | Metric | Docs |
+| Docs | Compiler | Metric | Example |
 |---------|----------|--------|------|
-| [NVCC reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvcc_example/) | NVCC | Runtime (ms) | [NVCC example](nvcc_example.md) |
-| [PTXAS spill reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/ptxas_example/) | PTXAS | Spill bytes | [PTXAS example](ptx_spill_example.md) |
-| [Triton matmul](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/triton_example/) | PTXAS via Triton | Runtime (ms) | [Triton example](triton_example.md) |
-| [cuTile matmul](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/cutile_example/) | cuTile user-level parameters | Runtime (ms) | [cuTile example](cutile_example.md) |
-| [NVBench reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvbench_example/) | PTXAS via NVCC | Runtime (P75, NVBench) | [Benchmarking](benchmarking.md) |
+| [NVCC example](nvcc_example.md) | NVCC | Runtime (ms) | [NVCC reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvcc_example/) |
+| [PTXAS example](ptx_spill_example.md) | PTXAS | Spill bytes | [PTXAS spill reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/ptxas_example/) |
+| [Triton example](triton_example.md) | PTXAS via Triton | Runtime (ms) | [Triton matmul](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/triton_example/) |
+| [cuTile example](cutile_example.md) | cuTile user-level parameters | Runtime (ms) | [cuTile matmul](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/cutile_example/) |
+| [Benchmarking](benchmarking.md) | PTXAS via NVCC | Runtime (P75, NVBench) | [NVBench reduction](https://github.com/NVIDIA/CompileIQ/blob/main/examples/compilers/nvbench_example/) |
 
 The PTXAS example is the simplest starting point — it only requires `ptxas` and runs on CPU (no GPU needed). The NVCC, Triton, and cuTile examples require a GPU to measure runtime.


### PR DESCRIPTION
## Description

This MR is a small documentation improvement. It swaps the `Docs` and `Example` column in the `Standalone Examples` sections table in `docs/compiler_overview.md` for improved readability.

closes #52 

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/CompileIQ/blob/main/CONTRIBUTING.md).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.

## Validation

N/a

## Bug fix

N/a

## New feature / enhancement

N/a
